### PR TITLE
Css prefixer issues.

### DIFF
--- a/src/adapter/css/prefixer.js
+++ b/src/adapter/css/prefixer.js
@@ -1,5 +1,4 @@
 const cache = {};
-const prefixes = ['Webkit','Moz','O','ms', ''];
 const prefixesFind = ['Webkit','Moz','O','ms', ''];
 const prefixesReplace = ['-webkit-','-moz-','-o-','-ms-', ''];
 const numPrefixes = prefixesFind.length;

--- a/src/adapter/css/prefixer.js
+++ b/src/adapter/css/prefixer.js
@@ -21,7 +21,7 @@ const testPrefix = (key) => {
 
     for (var i = 0; i < numPrefixes; i++) {
         var prefix = prefixesFind[i],
-            prefixed = (prefix === '') ? key : prefix + key.charAt(0).toUpperCase() + key.slice(1); //
+            prefixed = (prefix === '') ? key : prefix + key.charAt(0).toUpperCase() + key.slice(1);
 
         if (prefixed in testElement.style) {
             cache[key] = prefixesReplace[i] + key;

--- a/src/adapter/css/prefixer.js
+++ b/src/adapter/css/prefixer.js
@@ -1,6 +1,8 @@
 const cache = {};
 const prefixes = ['Webkit','Moz','O','ms', ''];
-const numPrefixes = prefixes.length;
+const prefixesFind = ['Webkit','Moz','O','ms', ''];
+const prefixesReplace = ['-webkit-','-moz-','-o-','-ms-', ''];
+const numPrefixes = prefixesFind.length;
 let testElement;
 
 /*
@@ -19,11 +21,11 @@ const testPrefix = (key) => {
     }
 
     for (var i = 0; i < numPrefixes; i++) {
-        var prefix = prefixes[i],
-            prefixed = (prefix === '') ? key : prefix + key.charAt(0).toUpperCase() + key.slice(1);
+        var prefix = prefixesFind[i],
+            prefixed = (prefix === '') ? key : prefix + key.charAt(0).toUpperCase() + key.slice(1); //
 
         if (prefixed in testElement.style) {
-            cache[key] = prefixed;
+            cache[key] = prefixesReplace[i] + key;
         }
     }
     


### PR DESCRIPTION
Hey,

I've ran into problems with css prefixing on iOS 8/Firefox.  It turns out prefixes were not getting passed properly.

I noticed popmotion is using *element.cssText* to set properties rather than setting *element.style*. The prefixer was passing transform properties as 'webkitTransform' into cssText rather than '-webkit-transform'.   cssText expects valid css rules rather than the Style property setter versions!

This fixed my issues on iOS 8 anyway.  Lets hope I never have to debug iOS 8 again!

I'd double check this commit as haven't re-compiled it - just applied the fix to my babelified version..
Should work though!

Cheers,

Jamie
