### PR TITLE
Inherit actions so unit is respected

### DIFF
--- a/src/actions/Flow.js
+++ b/src/actions/Flow.js
@@ -39,7 +39,7 @@ class Flow extends Action {
     // Create values on actor that don't exist
     for (let key in inheritedAction.values) {
       if (inheritedAction.values.hasOwnProperty(key) && !this.values.hasOwnProperty(key)) {
-        newValues[key] = {};
+        newValues[key] = inheritedAction.values[key];
         hasNewValues = true;
       }
     }

--- a/src/value-types/unit.js
+++ b/src/value-types/unit.js
@@ -9,7 +9,7 @@ export default {
   parse: function (unparsed, parent) {
     const { value, unit } = findValueAndUnit(unparsed);
 
-    if (unit && unit !== unit) {
+    if (unit && unit !== parent.unit) {
       parent.unit = unit;
     }
 


### PR DESCRIPTION
This is an attempt to resolve https://github.com/Popmotion/popmotion/issues/162: essentially, units are lost and always return to their value type default.

This PR fixes the problem. That being said, although I've got this working locally and all tests still pass, I'm not familiar enough with the codebase to have confidence that I'm not breaking something. If nothing else, hopefully this PR will help you find the source of the problem.
