### PR TITLE
Allow calculating the velocity of a value over a window of times to g…

### DIFF
--- a/docs/api/action/README.md
+++ b/docs/api/action/README.md
@@ -21,6 +21,7 @@ category: action
 - `start`: Start an action. Fires any set `onStart` callbacks.
 - `stop`: Stop an action. Fires `onStop` callback.
 - `get`: Get the current value.
+- `setVelocityWindow`: Sets the duration of a window to average over for for velocity calculation, in milliseconds.
 - `getVelocity`: Get the action's current velocity, in units per second.
 - `getBeforeTransform`: Returns the current value, without passing through `transform` if a `transform` function is defined.
 - `complete`: Stop an action and mark as complete. Fires `onStop` and `onComplete` callbacks.

--- a/docs/learn/basics/velocity-and-physics.md
+++ b/docs/learn/basics/velocity-and-physics.md
@@ -32,6 +32,12 @@ setTimeout(
 );
 ```
 
+By default, the velocity is calculated from the last two values. However, if you know your velocity is roughly linear, you may want to calculate the velocity using a window of values. To do this call the `setVelocityWindow` method with the number of milliseconds you want to sample over.
+
+```javascript
+myTween.setVelocityWindow(50);
+```
+
 ## Applying velocity to physics
 
 Now, let's apply that velocity to our ball from the input tracking tutorial. Let's first create a single `value` to [manage our actions](/learn/action-management).

--- a/src/actions/composite.js
+++ b/src/actions/composite.js
@@ -47,6 +47,10 @@ class CompositeAction extends Action {
     this.actionKeys.forEach((key) => this[key].stop());
   }
 
+  setVelocityWindow(velocityWindow) {
+    this.actionKeys.forEach((key) => this[key].setVelocityWindow(velocityWindow));
+  }
+
   getVelocity() {
     const velocity = {};
     this.actionKeys.forEach((key) => velocity[key] = this[key].getVelocity());

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -129,6 +129,10 @@ class Action { // lawsuit - sorry
     return this.props[key];
   }
 
+  setVelocityWindow(velocityWindow) {
+    this.velocityWindow = velocityWindow;
+  }
+
   getVelocity() {
     return speedPerSecond(
       this.prevValues[this.prevValues.length - 1] - this.prevValues[0],

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -11,8 +11,11 @@ class Action { // lawsuit - sorry
 
     this.setProps(props);
 
-    this.lastUpdated = 0;
-    this.prev = this.current = props.current || props.from || 0;
+    this.current = props.current || props.from || 0;
+    this.prevValues = [];
+    this.prevTimes = [];
+
+    this.velocityWindow = 0;
   }
 
   start() {
@@ -58,8 +61,14 @@ class Action { // lawsuit - sorry
   }
 
   scheduledUpdate() {
-    this.lastUpdated = timeSinceLastFrame();
-    this.prev = this.current;
+    const currentTime = this.prev[this.prev.length - 1].time + timeSinceLastFrame();
+    this.prevValues.push(this.current);
+    this.prevTimes.push(currentTime);
+
+    if (currentTime - this.prevTimes[0] > this.velocityWindow) {
+      this.prevValues.shift();
+      this.prevTimes.shift();
+    }
 
     const { onUpdate, passive } = this.props;
 
@@ -121,7 +130,10 @@ class Action { // lawsuit - sorry
   }
 
   getVelocity() {
-    return speedPerSecond(this.current - this.prev, this.lastUpdated);
+    return speedPerSecond(
+      this.prevValues[this.prevValues.length - 1] - this.prevValues[0],
+      this.prevTimes[this.prevTimes.length - 1] - this.prevTimes[0]
+    );
   }
 
   isActive() {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -65,7 +65,7 @@ class Action { // lawsuit - sorry
     this.prevValues.push(this.current);
     this.prevTimes.push(currentTime);
 
-    if (currentTime - this.prevTimes[0] > this.velocityWindow) {
+    while (currentTime - this.prevTimes[0] > this.velocityWindow) {
       this.prevValues.shift();
       this.prevTimes.shift();
     }


### PR DESCRIPTION
In Leaflet, the inertial panning is done by averaging the values of `{ x, y }` and `time` over (in Leaflet's case) 50ms. This PR allows you to add this behaviour by calling `action.setVelocityWindow(50)`, but leaves the behaviour off by default.

We use two arrays rather than one array of `{ value, time }` objects to remove the need for garbage collection.