### PR TITLE
fix: unable to remove event listener on old chrome version

### DIFF
--- a/packages/popmotion/src/input/listen/index.ts
+++ b/packages/popmotion/src/input/listen/index.ts
@@ -8,7 +8,7 @@ const listen: ListenFactory = (element, events, options) => action(({ update }) 
   });
 
   return {
-    stop: () => eventNames.forEach((eventName) => element.removeEventListener(eventName, update))
+    stop: () => eventNames.forEach((eventName) => element.removeEventListener(eventName, update, options))
   };
 });
 


### PR DESCRIPTION
This patch fix an issue related to listen action.
On old mobile chrome browser, listen.stop cannot remove the event listener when the options is set. It has the inconsistent behavior on the different browser.

Please see MDN doc related to `removeEventListener` for details.