### PR TITLE
popmotion-spinnable - add setRotate method

### DIFF
--- a/packages/popmotion-spinnable/src/index.js
+++ b/packages/popmotion-spinnable/src/index.js
@@ -60,6 +60,7 @@ export default function spinnable(node, {
   listen(document, 'mouseup touchend').start(stopTracking);
 
   return {
+    setRotate: (angle) => nodeStyler.set('rotate', angle),
     stop: () => active && active.stop()
   };
 }


### PR DESCRIPTION
adds a `setRotate` method to popmotion-spinnable, which allows overriding the result after initialisation