### PR TITLE
Add Ol component to the documentation

### DIFF
--- a/site/scripts/generate-content-page.js
+++ b/site/scripts/generate-content-page.js
@@ -6,7 +6,7 @@ module.exports = (
 ) => `
 import { createElement } from 'react';
 import marksy from 'marksy/components';
-import { A, H1, H2, H3, H4, P, Li, Ul, Hr, Code, Blockquote, ArticleHeader, Video } from '~/templates/global/styled';
+import { A, H1, H2, H3, H4, P, Li, Ol, Ul, Hr, Code, Blockquote, ArticleHeader, Video } from '~/templates/global/styled';
 import { Img } from '~/templates/content/styled';
 import ContentTemplate from '~/templates/content/Template';
 import Example from '~/components/examples/Example';
@@ -25,6 +25,7 @@ const convertMarkdown = marksy({
     p: P,
     code: Code,
     li: Li,
+    ol: Ol,
     ul: Ul,
     hr: Hr,
     img: Img,

--- a/site/templates/global/styled.js
+++ b/site/templates/global/styled.js
@@ -173,6 +173,13 @@ export const Code = ({ language, children, code }) =>
     </CodeBlock>
   );
 
+export const Ol = Centered.withComponent('ol').extend`
+  list-style-type: decimal;
+  padding-left: ${cols(2)};
+  max-width: ${cols(43)};
+  margin-bottom: 1.1rem;
+`;
+
 export const Ul = Centered.withComponent('ul').extend`
   list-style-type: disc;
   padding-left: ${cols(2)};


### PR DESCRIPTION
There is currently no component for `ol` elements, so the FLIP page looks like this:

![flip_current](https://user-images.githubusercontent.com/11573167/39296422-28b9c4bc-4941-11e8-8588-b9b38305976c.jpg)

This PR adds a `Ol` component that is used for `ol` elements, identical to the `Ul` component except that the `list-style-type` is decimal:

![flip_new](https://user-images.githubusercontent.com/11573167/39296466-438bd53c-4941-11e8-9ca9-663ba440429b.jpg)

