### PR TITLE
Handle step ranges of length 0

### DIFF
--- a/packages/popmotion/src/_tests/transformers.test.ts
+++ b/packages/popmotion/src/_tests/transformers.test.ts
@@ -99,6 +99,13 @@ describe('steps()', () => {
     expect(threeStep(49)).toBe(50);
     expect(threeStep(75)).toBe(100);
   });
+
+  it('should handle a range of length 0', () => {
+    const threeStep = steps(3, 4, 4);
+    expect(threeStep(0)).toBe(4);
+    expect(threeStep(4)).toBe(4);
+    expect(threeStep(8)).toBe(4);
+  });
 });
 
 describe('snap()', () => {

--- a/packages/popmotion/src/calc.ts
+++ b/packages/popmotion/src/calc.ts
@@ -108,8 +108,11 @@ export const distance = (a: Point | number, b: Point | number = ZERO_POINT): num
   @param [number]: Value to find progress within given range
   @return [number]: Progress of value within range as expressed 0-1
 */
-export const getProgressFromValue = (from: number, to: number, value: number) =>
-  (value - from) / (to - from);
+export const getProgressFromValue = (from: number, to: number, value: number) => {
+  const toFromDifference = to - from;
+
+  return toFromDifference === 0 ? 1 : (value - from) / toFromDifference;
+}
 
 /*
   Value in range from progress


### PR DESCRIPTION
Step ranges of length 0 results in `getProgressFromValue` dividing by 0, which makes the function returned from `steps` return `NaN` for every step given to it.

Returning a progress of `1` when the range is of length 0 resolves the issue. 

Closes https://github.com/Popmotion/popmotion/issues/274