### PR TITLE
only call onDragEnd once

### DIFF
--- a/packages/react-native-pose/src/index.ts
+++ b/packages/react-native-pose/src/index.ts
@@ -97,7 +97,6 @@ const posed = createPosed({
         if (onDragEnd) onDragEnd(e, gestureState);
         if (dragX) values.x.flattenOffset();
         if (dragY) values.y.flattenOffset();
-        if (onDragEnd) onDragEnd(e, gestureState);
         poser.set('dragEnd', { gestureState });
       }
     });


### PR DESCRIPTION
I was playing with react native draggable components and I noticed that `onDragEnd` is being called twice. I took a look at the source and saw that it was explicitly being called twice, and I think that's unintentional. Here's a PR to get rid of that extra call