### PR TITLE
Remove unused dev dependencies

### DIFF
--- a/packages/popmotion/package.json
+++ b/packages/popmotion/package.json
@@ -63,8 +63,6 @@
     "rollup-plugin-typescript2": "^0.14.0",
     "rollup-plugin-uglify": "^3.0.0",
     "ts-jest": "^21.2.4",
-    "ts-list": "^1.0.5",
-    "ts-loader": "^3.5.0",
     "tslint-circular-dependencies": "^0.1.0",
     "typescript": "^2.7.2"
   },


### PR DESCRIPTION
Looks like `ts-loader` stopped being used when Rollup was introduced and `ts-list` I can't find within the code base either