### PR TITLE
Allow PoseGroup to take a single child

### DIFF
--- a/packages/react-pose/src/components/PoseGroup.tsx
+++ b/packages/react-pose/src/components/PoseGroup.tsx
@@ -8,7 +8,7 @@ import {
 const { Fragment } = React;
 
 export type Props = {
-  children: Array<ReactElement<any>>;
+  children: React.ReactElement<any> | Array<React.ReactElement<any>>;
   flipMove?: boolean;
   preEnterPose?: string;
   enterPose?: string;
@@ -42,11 +42,15 @@ class PoseGroup extends React.Component<Props, State> {
     return {
       incomingChildren,
       children: handleIncomingChildren({
-        ...props,
         incomingChildren,
         displayedChildren: children,
         isLeaving,
-        removeFromTree
+        removeFromTree,
+        enterPose: props.enterPose,
+        exitPose: props.exitPose,
+        flipMove: props.flipMove,
+        animateOnMount: props.animateOnMount,
+        preEnterPose: props.preEnterPose
       })
     };
   };

--- a/packages/react-pose/src/utils/children.ts
+++ b/packages/react-pose/src/utils/children.ts
@@ -1,11 +1,19 @@
 import * as React from 'react';
 import { ReactElement } from 'react';
 import { CurrentPose } from '../components/PoseElement.types';
-import { Props, State } from '../components/PoseGroup';
 const { Children, cloneElement } = React;
 
-type MergeChildrenProps = Props &
-  State & { displayedChildren: Array<ReactElement<any>> };
+interface MergeChildrenProps {
+  incomingChildren: Array<React.ReactElement<any>>;
+  displayedChildren: Array<React.ReactElement<any>>;
+  isLeaving: Set<string>;
+  removeFromTree: (key: string) => void
+  preEnterPose: string
+  enterPose: string
+  exitPose: string
+  flipMove: boolean
+  animateOnMount: boolean
+}
 
 const getKey = (child: ReactElement<any>): string => child.key as string;
 
@@ -112,7 +120,7 @@ export const handleIncomingChildren = (props: MergeChildrenProps) => {
   }
 };
 
-export const makeChildList = (children: Array<ReactElement<any>>) => {
+export const makeChildList = (children: Array<ReactElement<any>> | ReactElement<any>) => {
   const list: Array<ReactElement<any>> = [];
   Children.forEach(
     children,


### PR DESCRIPTION
In addition to controlling multiple animated children, `PoseGroup` is useful for ensuring a single child component will transition to the correct pose before unmounting. The current types force you to wrap the children in an array and this PR simply changes those types to allow `PoseGroup` to have a single child.

I didn't unfortunately manage to test this locally due to unbuilt internal Popmotion dependencies and a missing script for building all packages at once. 😕 