### PR TITLE
Add document touch listeners lazily

### DIFF
--- a/packages/popmotion/src/input/multitouch/index.ts
+++ b/packages/popmotion/src/input/multitouch/index.ts
@@ -41,6 +41,9 @@ const removePointsListener = () => {
     if (pointsListener && pointsListener.stop) {
       pointsListener.stop();
       pointsListener = undefined;
+
+      points.splice(1);
+      points[0] = defaultPointerPos();
     }
   }
 };

--- a/packages/popmotion/src/input/multitouch/index.ts
+++ b/packages/popmotion/src/input/multitouch/index.ts
@@ -4,27 +4,46 @@ import { angle, distance } from '../../calc';
 import listen from '../listen';
 import { PointerPoint, PointerProps } from '../pointer/types';
 import { defaultPointerPos, eventToPoint } from '../pointer/utils';
+import { ColdSubscription } from '../../action/types';
 
 const points: PointerPoint[] = [defaultPointerPos()];
 let isTouchDevice = false;
 
-if (typeof document !== 'undefined') {
-  const updatePointsLocation = ({ touches }: TouchEvent) => {
-    isTouchDevice = true;
-    const numTouches = touches.length;
+let listenerCount = 0;
+let pointsListener: ColdSubscription | void;
 
-    // TODO: Optimisation would be to provide existing points to `eventToPoint`
-    points.length = 0;
+const updatePointsLocation = ({ touches }: TouchEvent) => {
+  isTouchDevice = true;
+  const numTouches = touches.length;
 
-    for (let i = 0; i < numTouches; i++) {
-      const thisTouch = touches[i];
-      points.push(eventToPoint(thisTouch));
+  // TODO: Optimisation would be to provide existing points to `eventToPoint`
+  points.length = 0;
+
+  for (let i = 0; i < numTouches; i++) {
+    const thisTouch = touches[i];
+    points.push(eventToPoint(thisTouch));
+  }
+};
+
+const addPointsListener = () => {
+  listenerCount += 1;
+
+  if (typeof document !== 'undefined' && !pointsListener) {
+    pointsListener = listen(document, 'touchstart touchmove', true)
+      .start(updatePointsLocation);
+  }
+};
+
+const removePointsListener = () => {
+  listenerCount -= 1;
+
+  if (listenerCount < 1) {
+    if (pointsListener && pointsListener.stop) {
+      pointsListener.stop();
+      pointsListener = undefined;
     }
-  };
-
-  listen(document, 'touchstart touchmove', true)
-    .start(updatePointsLocation);
-}
+  }
+};
 
 const multitouch = ({ preventDefault = true, scale = 1.0, rotate = 0.0 }: PointerProps = {}): Action => action(({ update }) => {
   const output = {
@@ -62,6 +81,8 @@ const multitouch = ({ preventDefault = true, scale = 1.0, rotate = 0.0 }: Pointe
     onFrameUpdate(updatePoint);
   };
 
+  addPointsListener();
+
   const updateOnMove = listen(document, 'touchmove', { passive: !preventDefault })
     .start(onMove);
 
@@ -69,6 +90,7 @@ const multitouch = ({ preventDefault = true, scale = 1.0, rotate = 0.0 }: Pointe
 
   return {
     stop: () => {
+      removePointsListener();
       cancelOnFrameUpdate(updatePoint);
       updateOnMove.stop();
     }


### PR DESCRIPTION
Only add document touch listeners when anyone is actually interested in them – it feels pretty wasteful to add such listeners whenever the Popmotion library is included, no matter if one uses the code or not (could be solved by doing some tree shaking, but not everyone has a build environment set up for that, eg. is using commonjs and Browserify)

This should have no real side-effects as `updatePointsLocation()` replaces the content of  `points` every time it's invoked – so there's really no need to track anything prior to the creation of a multitouch input and since its still ensured that only one global listener is added.

Only small edge case is if a touch is already happening when the multitouch input is happening – then that touch won't be detected until the next `touchstart` or `touchmove` – but I think that is acceptable considering the benefits of not _always_ having touch listeners when one includes Popmotion, no matter if one uses the multitouch input or not?
