### PR TITLE
Fix hasChanged returning false when array items change

### DIFF
--- a/packages/react-pose-core/src/_tests/utils.tests.ts
+++ b/packages/react-pose-core/src/_tests/utils.tests.ts
@@ -7,6 +7,7 @@ test('Correctly detects if a pose has changed', () => {
   const aArr2 = ['a'];
   const bArr = ['a', 'b'];
   const bArr2 = ['a', 'b'];
+  const cArr = ['a', 'c'];
 
   // Hasn't changed
   expect(hasChanged(a, a)).toBe(false);
@@ -17,4 +18,5 @@ test('Correctly detects if a pose has changed', () => {
   // Has changed
   expect(hasChanged(a, b)).toBe(true);
   expect(hasChanged(aArr, bArr)).toBe(true);
+  expect(hasChanged(bArr, cArr)).toBe(true);
 });

--- a/packages/react-pose-core/src/utils.ts
+++ b/packages/react-pose-core/src/utils.ts
@@ -38,7 +38,7 @@ export const hasChanged = (prev: CurrentPose, next: CurrentPose): boolean => {
 
     if (numPrev !== numNext) return true;
 
-    for (let i = numPrev; i < numPrev; i++) {
+    for (let i = 0; i < numPrev; i++) {
       if (prev[i] !== next[i]) return true;
     }
   }


### PR DESCRIPTION
Just found this issue while playing with react-pose.
When change some items in the array of poses, if the number of items is the same, the new pose does not work, eg:
```tsx
<PosedDiv pose={["flip", expanded ? "expanded" : "collapsed"} />
```