### PR TITLE
Extracted @popmotion/easing package

### DIFF
--- a/packages/easing/package.json
+++ b/packages/easing/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "popmotion",
-  "version": "8.3.3",
-  "description": "A functional, reactive motion library.",
+  "name": "@popmotion/easing",
+  "version": "0.0.0",
+  "description": "A set of modular easing equations.",
   "author": "Matt Perry",
   "homepage": "https://popmotion.io",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
-  "module": "dist/popmotion.es.js",
-  "jsnext:main": "dist/popmotion.es.js",
+  "module": "dist/easing.es.js",
+  "jsnext:main": "dist/easing.es.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Popmotion/popmotion/tree/master/packages/popmotion"
+    "url": "https://github.com/Popmotion/popmotion/tree/master/packages/easing"
   },
   "bugs": {
     "url": "https://github.com/Popmotion/popmotion/issues"
@@ -23,15 +23,9 @@
     "canvas animation",
     "dom animation",
     "dom",
-    "pointer tracking",
-    "mouse",
-    "mouse tracking",
-    "touch",
-    "touch tracking",
     "physics",
     "interaction",
-    "interface",
-    "svg"
+    "interface"
   ],
   "analyze": true,
   "license": "MIT",
@@ -45,14 +39,6 @@
     "test": "jest",
     "publish-beta": "npm publish --tag beta",
     "clean": "git clean -fd -e node_modules/ -e lib/ src/ -x ."
-  },
-  "dependencies": {
-    "@popmotion/easing": "^0.0.0",
-    "framesync": "^3.1.9",
-    "hey-listen": "^1.0.5",
-    "style-value-types": "^3.0.3",
-    "stylefire": "^2.0.6",
-    "tslib": "^1.9.1"
   },
   "devDependencies": {
     "@types/jest": "^23.1.1",
@@ -84,7 +70,6 @@
     "testRegex": "/_tests/.*\\.(ts|js)$",
     "rootDir": "src"
   },
-  "unpkg": "./dist/popmotion.global.min.js",
   "prettier": {
     "parser": "typescript",
     "singleQuote": true

--- a/packages/easing/rollup.config.js
+++ b/packages/easing/rollup.config.js
@@ -1,0 +1,47 @@
+import typescript from 'rollup-plugin-typescript2';
+import resolve from 'rollup-plugin-node-resolve';
+import pkg from './package.json';
+
+const typescriptConfig = {
+  cacheRoot: 'tmp/.rpt2_cache',
+  typescript: require('typescript')
+};
+const noDeclarationConfig = Object.assign({}, typescriptConfig, {
+  tsconfigOverride: { compilerOptions: { declaration: false } }
+});
+
+const makeExternalPredicate = externalArr => {
+  if (externalArr.length === 0) {
+    return () => false;
+  }
+  const pattern = new RegExp(`^(${externalArr.join('|')})($|/)`);
+  return id => pattern.test(id);
+};
+
+const deps = Object.keys(pkg.dependencies || {});
+const peerDeps = Object.keys(pkg.peerDependencies || {});
+
+const config = {
+  input: 'src/index.ts',
+  external: makeExternalPredicate(deps.concat(peerDeps))
+};
+
+const es = Object.assign({}, config, {
+  output: {
+    file: pkg.module,
+    format: 'es',
+    exports: 'named'
+  },
+  plugins: [resolve(), typescript(noDeclarationConfig)]
+});
+
+const cjs = Object.assign({}, config, {
+  output: {
+    file: pkg.main,
+    format: 'cjs',
+    exports: 'named'
+  },
+  plugins: [resolve(), typescript(typescriptConfig)]
+});
+
+export default [es, cjs];

--- a/packages/easing/src/_tests/index.test.ts
+++ b/packages/easing/src/_tests/index.test.ts
@@ -1,7 +1,7 @@
 import {
   cubicBezier,
   linear
-} from '../easing';
+} from '..';
 
 describe('', () => {
   it('should return a series of correct, functioning easing functions', () => {

--- a/packages/easing/src/index.ts
+++ b/packages/easing/src/index.ts
@@ -33,14 +33,14 @@ export const anticipate = createAnticipateEasing(DEFAULT_OVERSHOOT_STRENGTH);
 
 /*
   Bezier function generator
-    
+
   Gaëtan Renaudeau's BezierEasing
-  https://github.com/gre/bezier-easing/blob/master/index.js  
+  https://github.com/gre/bezier-easing/blob/master/index.js
   https://github.com/gre/bezier-easing/blob/master/LICENSE
   You're a hero
-  
+
   Use
-  
+
     var easeOut = new Bezier(.17,.67,.83,.67),
       x = easeOut(0.5); // returns 0.627...
 */
@@ -95,15 +95,15 @@ export function cubicBezier(mX1: number, mY1: number, mX2: number, mY2: number) 
 
     for (; i < NEWTON_ITERATIONS; ++i) {
       currentSlope = getSlope(aGuessT, mX1, mX2);
-      
+
       if (currentSlope === 0.0) {
         return aGuessT;
       }
-      
+
       currentX = calcBezier(aGuessT, mX1, mX2) - aX;
       aGuessT -= currentX / currentSlope;
     }
-    
+
     return aGuessT;
   };
 
@@ -120,18 +120,18 @@ export function cubicBezier(mX1: number, mY1: number, mX2: number, mY2: number) 
     let dist = 0.0;
     let guessForT = 0.0;
     let initialSlope = 0.0;
-      
+
     for (; currentSample != lastSample && sampleValues[currentSample] <= aX; ++currentSample) {
       intervalStart += K_SAMPLE_STEP_SIZE;
     }
-    
+
     --currentSample;
-    
+
     dist = (aX - sampleValues[currentSample]) / (sampleValues[currentSample+1] - sampleValues[currentSample]);
     guessForT = intervalStart + dist * K_SAMPLE_STEP_SIZE;
-    
+
     initialSlope = getSlope(guessForT, mX1, mX2);
-    
+
     // If slope is greater than min
     if (initialSlope >= NEWTON_MIN_SLOPE) {
       return newtonRaphsonIterate(aX, guessForT);

--- a/packages/easing/tsconfig.json
+++ b/packages/easing/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/popmotion/src/animations/keyframes/_tests/keyframes.test.ts
+++ b/packages/popmotion/src/animations/keyframes/_tests/keyframes.test.ts
@@ -1,5 +1,5 @@
 import keyframes from '../';
-import { linear } from '../../../easing';
+import { linear } from '@popmotion/easing';
 
 describe('keyframes', () => {
   it('should generate tweens through each value', () => {

--- a/packages/popmotion/src/animations/keyframes/index.ts
+++ b/packages/popmotion/src/animations/keyframes/index.ts
@@ -1,6 +1,6 @@
 import { Action } from '../../action';
 import { getProgressFromValue } from '../../calc';
-import { easeOut, Easing, linear } from '../../easing';
+import { easeOut, Easing, linear } from '@popmotion/easing';
 import { Update } from '../../observer/types';
 import { clamp } from '../../transformers';
 import tween from '../tween';

--- a/packages/popmotion/src/animations/keyframes/types.ts
+++ b/packages/popmotion/src/animations/keyframes/types.ts
@@ -1,4 +1,4 @@
-import { Easing } from '../../easing';
+import { Easing } from '@popmotion/easing';
 
 export type ValueMap = {
   [key: string]: string | number

--- a/packages/popmotion/src/animations/timeline/index.ts
+++ b/packages/popmotion/src/animations/timeline/index.ts
@@ -2,7 +2,7 @@ import { Action } from '../../action';
 import { AnimationDefinition, Instruction, Tracks, TrackActions } from './types';
 import keyframes from '../keyframes';
 import { KeyframeProps } from '../keyframes/types';
-import { easeInOut, linear } from '../../easing';
+import { easeInOut, linear } from '@popmotion/easing';
 import composite from '../../compositors/composite';
 import { TweenProps } from '../tween/types';
 import { Value } from '../../reactions/value';

--- a/packages/popmotion/src/animations/timeline/types.ts
+++ b/packages/popmotion/src/animations/timeline/types.ts
@@ -1,6 +1,6 @@
 import { Value } from '../../reactions/value';
 import { Action } from '../../action';
-import { Easing } from '../../easing';
+import { Easing } from '@popmotion/easing';
 
 export type AnimationDefinition = {
   track: string,

--- a/packages/popmotion/src/animations/tween/index.ts
+++ b/packages/popmotion/src/animations/tween/index.ts
@@ -2,7 +2,7 @@ import { onFrameUpdate, timeSinceLastFrame } from 'framesync';
 import action, { Action } from '../../action';
 import { ColdSubscription } from '../../action/types';
 import { getProgressFromValue, getValueFromProgress } from '../../calc';
-import { easeOut } from '../../easing';
+import { easeOut } from '@popmotion/easing';
 import { IObserver } from '../../observer/types';
 import { clamp } from '../../transformers';
 import onFrame from '../every-frame';

--- a/packages/popmotion/src/animations/tween/scrubber.ts
+++ b/packages/popmotion/src/animations/tween/scrubber.ts
@@ -2,7 +2,7 @@ import { number } from 'style-value-types';
 import action, { Action } from '../../action';
 import vectorAction, { ActionFactory } from '../../action/vector';
 import { getValueFromProgress } from '../../calc';
-import { linear } from '../../easing';
+import { linear } from '@popmotion/easing';
 
 export type ScrubberSubscription = {
   seek: (progress: number) => any;

--- a/packages/popmotion/src/animations/tween/types.ts
+++ b/packages/popmotion/src/animations/tween/types.ts
@@ -1,5 +1,5 @@
 import { Value } from '../../reactions/value';
-import { Easing } from '../../easing';
+import { Easing } from '@popmotion/easing';
 
 export type TweenProps = {
   from?: Value,

--- a/packages/popmotion/src/index.ts
+++ b/packages/popmotion/src/index.ts
@@ -47,7 +47,7 @@ export {
 
 // Includes
 import * as calc from './calc';
-import * as easing from './easing';
+import * as easing from '@popmotion/easing';
 import * as transform from './transformers';
 
 export { calc, easing, transform };

--- a/packages/popmotion/src/transformers.ts
+++ b/packages/popmotion/src/transformers.ts
@@ -6,13 +6,13 @@ import {
   smooth as calcSmoothing,
   stepProgress
 } from './calc';
-import { Easing } from './easing';
+import { Easing } from '@popmotion/easing';
 
 const noop = (v: any): any => v;
 
 /**
  * Append Unit
- * A function that will append
+ * A function that will appendw
  * appendUnit('px', 20) -> '20px'
  * @param  {string} unit)
  * @return {number}


### PR DESCRIPTION
This is probably not yet ready to merge - I'm not sure how to properly test this in this monorepo setup.

**Why?**
Those easing functions are extremely useful & I'd like to import a single one and let tree-shaking to its thing to leave only the imported one in my bundles, but it's not possible in current setup - because I have to import whole `easing` object from `popmotion` library (which holds also higher risk that some other things from that lib might not get tree-shaken properly and would leave me with bigger bundles).
