### PR TITLE
Rename noop to identity

### DIFF
--- a/packages/popmotion/src/transformers.ts
+++ b/packages/popmotion/src/transformers.ts
@@ -8,7 +8,7 @@ import {
 } from './calc';
 import { Easing } from '@popmotion/easing';
 
-const noop = (v: any): any => v;
+const identity = (v: any): any => v;
 
 /**
  * Append Unit
@@ -194,7 +194,7 @@ export const interpolate = (
     : fastInterpolate(input[0], input[1], output[0], output[1]);
 };
 
-export const generateStaticSpring = (alterDisplacement: Function = noop) => (
+export const generateStaticSpring = (alterDisplacement: Function = identity) => (
   constant: number,
   origin: number
 ) => (v: number) => {


### PR DESCRIPTION
Imho `noop` is more often used for `() => {}`, while `identity` is a common name for `a => a`