### PR TITLE
react-pose: Fix component argument type in `posed`

### DIFF
--- a/packages/react-pose/src/posed.tsx
+++ b/packages/react-pose/src/posed.tsx
@@ -13,7 +13,7 @@ export type ComponentFactory = (
 ) => (props: PoseElementProps) => ReactElement<any>;
 
 export type Posed = {
-  (component: React.Component): ComponentFactory;
+  (component: React.ComponentType): ComponentFactory;
   [key: string]: ComponentFactory;
 };
 


### PR DESCRIPTION
The `component` argument in `posed` was `React.Component` which would only allow _instances_ of `React.Component` subclasses. [The documentation][1] states that a component constructor needs to be passed to `posed` for custom components, so the type needs to be `React.ComponentType` to allow class component constructors and stateless components.

[1]: https://popmotion.io/pose/api/posed/#{{0}}-usage-create-a-posed-component-existing-components