### PR TITLE
[Documentation] fix link targets for links to stylefire docs

### DIFF
--- a/packages/site/pages/pure/api/css.js
+++ b/packages/site/pages/pure/api/css.js
@@ -35,7 +35,7 @@ const convertMarkdown = marksy({
 });
 
 const content = convertMarkdown(`
-[Moved to the Stylefire docs](/stylefire/api/styler/html).`);
+[Moved to the Stylefire docs](/stylefire/api/html).`);
 
 const Page = ({ section }) => (
   <ContentTemplate

--- a/packages/site/pages/pure/api/scroll.js
+++ b/packages/site/pages/pure/api/scroll.js
@@ -35,7 +35,7 @@ const convertMarkdown = marksy({
 });
 
 const content = convertMarkdown(`
-[Moved to the Stylefire docs](/stylefire/api/styler/viewport).`);
+[Moved to the Stylefire docs](/stylefire/api/viewport).`);
 
 const Page = ({ section }) => (
   <ContentTemplate

--- a/packages/site/pages/pure/api/svg.js
+++ b/packages/site/pages/pure/api/svg.js
@@ -35,7 +35,7 @@ const convertMarkdown = marksy({
 });
 
 const content = convertMarkdown(`
-[Moved to the Stylefire docs](/stylefire/api/styler/svg).`);
+[Moved to the Stylefire docs](/stylefire/api/svg).`);
 
 const Page = ({ section }) => (
   <ContentTemplate


### PR DESCRIPTION
Links to stylers in the stylefire documentation point to the right URL now.

You can test the current (wrong) state on the live site:

* go for example to: https://popmotion.io/api/svg/
* try clicking on "Moved to stylefire docs"