### PR TITLE
correctly check the current `poseKey` against the previous `poseKey`

### DIFF
--- a/packages/react-pose/src/components/PoseElement.tsx
+++ b/packages/react-pose/src/components/PoseElement.tsx
@@ -223,7 +223,7 @@ class PoseElement extends React.PureComponent<PoseElementInternalProps> {
     this.poser.setProps(this.getSetProps());
 
     if (
-      poseKey !== prevProps.key ||
+      poseKey !== prevProps.poseKey ||
       hasChanged(prevProps.pose, pose) ||
       pose === 'flip'
     ) {


### PR DESCRIPTION
See the diff, it's pretty self-explanatory.