### PR TITLE
Rewrite testVectorProps to use []#some instead of []#reduce

### DIFF
--- a/packages/popmotion/src/action/vector.ts
+++ b/packages/popmotion/src/action/vector.ts
@@ -74,10 +74,7 @@ const createVectorTests: VectorTestFactory = typeTests => {
 
   const testVectorProps = (props: Props) =>
     props &&
-    testNames.reduce(
-      (isVector, key) => isVector || isVectorProp(props[key], key),
-      false
-    );
+    testNames.some(key => isVectorProp(props[key], key));
 
   return { getVectorKeys, testVectorProps };
 };


### PR DESCRIPTION
This is both shorter & should be able to exit the iteration sooner.