### PR TITLE
Set if isTouchDevice

### DIFF
--- a/packages/popmotion/src/input/multitouch/index.ts
+++ b/packages/popmotion/src/input/multitouch/index.ts
@@ -79,6 +79,7 @@ const multitouch = ({
       stop: () => {
         cancelOnFrameUpdate(updatePoint);
         updateOnMove.stop();
+        isTouchDevice = false;
       }
     };
   });


### PR DESCRIPTION
Fix for devices with touchscreens and mouse input. As detailed in #265  currently once an element is dragged, the mouse input stops working.

