### PR TITLE
Fixed resolving position when flipping

### DIFF
--- a/packages/popmotion-pose/src/dom/flip.ts
+++ b/packages/popmotion-pose/src/dom/flip.ts
@@ -75,14 +75,14 @@ const explicitlyFlipPose = (state: PoserState, nextPose: Pose) => {
     ...remainingPose
   } = nextPose;
 
-  const propsToSet = positionalProps.reduce(
+  const propsToSet = positionalProps.concat('position').reduce(
     (acc, key) => {
       if (nextPose[key] !== undefined) {
         acc[key] = resolveProp(nextPose[key], state.props);
       }
       return acc;
     },
-    { position } as StyleMap
+    {} as StyleMap
   );
 
   elementStyler.set(propsToSet).render();


### PR DESCRIPTION
Fixes #353

Alternatively maybe `'position'` should be a `positionalProp` too? Didn't want to make such a change though, because I'm not sure what unexpected consequences it could have.