### PR TITLE
Alternative fix/override child props

### DIFF
--- a/packages/popmotion-pose/CHANGELOG.md
+++ b/packages/popmotion-pose/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Popmotion Pose adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.4.0] 2018-09-18
+
+### Added
+
+- Support for `dragBounds` as a function resolver.
+
 ## [3.3.0] 2018-09-06
 
 ### Added

--- a/packages/react-pose-core/src/components/PoseComponent.tsx
+++ b/packages/react-pose-core/src/components/PoseComponent.tsx
@@ -89,7 +89,7 @@ class PoseComponent extends React.PureComponent<PoseComponentProps> {
     const poseList: string[] = Array.isArray(pose) ? pose : [pose];
 
     Promise.all(poseList.map(key => key && this.poser.set(key))).then(
-      () => onPoseComplete && onPoseComplete()
+      () => onPoseComplete && onPoseComplete(pose)
     );
   }
 

--- a/packages/react-pose/CHANGELOG.md
+++ b/packages/react-pose/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-React Pose adheres to [Semantic Versioning](http://semver.org/).
+Pose for React adheres to [Semantic Versioning](http://semver.org/).
+
+## [3.3.4] 2018-09-18
+
+### Fixed
+
+- **Actively** filtering props from children that may have previously been set by `PoseGroup` itself.
 
 ## [3.3.3] 2018-09-17
 

--- a/packages/react-pose/src/_tests/index.test.tsx
+++ b/packages/react-pose/src/_tests/index.test.tsx
@@ -251,18 +251,21 @@ test('PoseGroup: Override props on child', () => {
         enterPose="dynamicEnter"
         exitPose="dynamicExit"
         preEnterPose="dynamicExit"
-        x={101}
+        x={isVisible ? 101 : 333}
+        onPoseComplete={() => {
+          if (isVisible) {
+            expect(x).toBe(202);
+            expect(y).toBe(75);
+            wrapper.setProps({ isVisible: false });
+          } else {
+            expect(x).toBe(333);
+            expect(y).toBe(85);
+            resolve();
+          }
+        }}
       >
         {isVisible && (
-          <Parent
-            key="a"
-            onPoseComplete={() => {
-              expect(x).toBe(202);
-              expect(y).toBe(75);
-              resolve();
-            }}
-            onValueChange={{ x: v => (x = v) }}
-          >
+          <Parent key="a" onValueChange={{ x: v => (x = v) }}>
             <Child onValueChange={{ y: v => (y = v) }} />
           </Parent>
         )}

--- a/packages/react-pose/src/_tests/index.test.tsx
+++ b/packages/react-pose/src/_tests/index.test.tsx
@@ -252,20 +252,24 @@ test('PoseGroup: Override props on child', () => {
         exitPose="dynamicExit"
         preEnterPose="dynamicExit"
         x={isVisible ? 101 : 333}
-        onPoseComplete={() => {
-          if (isVisible) {
-            expect(x).toBe(202);
-            expect(y).toBe(75);
-            wrapper.setProps({ isVisible: false });
-          } else {
-            expect(x).toBe(333);
-            expect(y).toBe(85);
-            resolve();
-          }
-        }}
       >
         {isVisible && (
-          <Parent key="a" onValueChange={{ x: v => (x = v) }}>
+          <Parent
+            key="a"
+            onPoseComplete={pose => {
+              if (pose === 'dynamicExit') {
+                expect(x).toBe(333);
+                expect(y).toBe(85);
+
+                resolve();
+              } else {
+                expect(x).toBe(202);
+                expect(y).toBe(75);
+                wrapper.setProps({ isVisible: false });
+              }
+            }}
+            onValueChange={{ x: v => (x = v) }}
+          >
             <Child onValueChange={{ y: v => (y = v) }} />
           </Parent>
         )}

--- a/packages/react-pose/src/components/PoseElement/index.tsx
+++ b/packages/react-pose/src/components/PoseElement/index.tsx
@@ -15,7 +15,7 @@ import {
 import isValidProp from '@emotion/is-prop-valid';
 import { invariant } from 'hey-listen';
 import { hasChanged } from '../../utils/has-changed';
-import { pickAssign } from '../../utils/pick-assign';
+import { pickAssign } from '../../utils/object-assign';
 
 export const PoseParentContext = createContext({});
 

--- a/packages/react-pose/src/components/PoseElement/index.tsx
+++ b/packages/react-pose/src/components/PoseElement/index.tsx
@@ -280,7 +280,7 @@ class PoseElement extends React.PureComponent<PoseElementInternalProps> {
     const poseList: string[] = Array.isArray(pose) ? pose : [pose];
 
     Promise.all(poseList.map(key => key && this.poser.set(key))).then(
-      () => onPoseComplete && onPoseComplete()
+      () => onPoseComplete && onPoseComplete(pose)
     );
   }
 

--- a/packages/react-pose/src/components/PoseElement/types.ts
+++ b/packages/react-pose/src/components/PoseElement/types.ts
@@ -23,6 +23,7 @@ export type PoseElementProps = {
   _pose?: CurrentPose;
   initialPose?: CurrentPose;
   withParent?: boolean;
+  onPoseComplete?: (pose: CurrentPose) => any;
   onValueChange?: { [key: string]: (v: any) => any };
   innerRef?: { current: any } | RefFunc;
   [key: string]: any;

--- a/packages/react-pose/src/components/Transition/children.ts
+++ b/packages/react-pose/src/components/Transition/children.ts
@@ -21,22 +21,20 @@ const animateChildrenList = (
 
 const mergeChildren = ({
   incomingChildren,
-  displayedChildren,
+  children,
   isLeaving,
   removeFromTree,
   groupProps
 }: MergeChildrenProps) => {
   const {
-    children: groupChildren,
     preEnterPose,
     enterPose,
     exitPose,
     flipMove,
-    animateOnMount,
   } = groupProps;
-  const children: Array<ReactElement<any>> = [];
+  const mergedChildren: Array<ReactElement<any>> = [];
 
-  const prevKeys = displayedChildren.map(getKey);
+  const prevKeys = children.map(getKey);
   const nextKeys = incomingChildren.map(getKey);
 
   const entering = new Set(
@@ -73,11 +71,11 @@ const mergeChildren = ({
       newChildProps._pose = enterPose;
     }
 
-    children.push(cloneElement(child, newChildProps));
+    mergedChildren.push(cloneElement(child, newChildProps));
   });
 
   leaving.forEach(key => {
-    const child = displayedChildren.find(c => c.key === key);
+    const child = children.find(c => c.key === key);
     const removeChildFromTree = removeFromTree(key)
 
     const newChild = cloneElement(child, {
@@ -100,22 +98,22 @@ const mergeChildren = ({
     // TODO: Write a shitty algo
     // }
 
-    children.splice(insertionIndex, 0, newChild);
+    mergedChildren.splice(insertionIndex, 0, newChild);
   });
 
-  return children;
+  return mergedChildren;
 };
 
 export const handleIncomingChildren = (props: MergeChildrenProps) => {
-  const { displayedChildren, incomingChildren, groupProps } = props;
+  const { children, incomingChildren, groupProps } = props;
   const { animateOnMount, preEnterPose, enterPose } = groupProps;
 
   // If initial mount and we're animating
-  if (!displayedChildren && animateOnMount) {
+  if (!children && animateOnMount) {
     return animateChildrenList(incomingChildren, enterPose, preEnterPose);
 
     // If subsequent render
-  } else if (displayedChildren) {
+  } else if (children) {
     return mergeChildren(props);
 
     // If initial mount and we're not animating

--- a/packages/react-pose/src/components/Transition/children.ts
+++ b/packages/react-pose/src/components/Transition/children.ts
@@ -2,11 +2,15 @@ import * as React from 'react';
 import { ReactElement } from 'react';
 import { CurrentPose } from '../PoseElement/types';
 import { MergeChildrenProps, Props } from './types';
+import { filterBy } from '../../utils/object-assign';
 const { Children, cloneElement } = React;
 
 const getKey = (child: ReactElement<any>): string => child.key as string;
 
-const filterChildProps = ({ children, _pose, onPoseComplete, popFromFlow, ...props }: Props) => props;
+const filterChildProps = (
+  { children, _pose, onPoseComplete, popFromFlow, ...props }: Props,
+  filterKeys?: string[]
+) => (filterKeys ? filterBy(props, filterKeys) : props);
 
 const animateChildrenList = (
   incomingChildren: Array<ReactElement<any>>,
@@ -68,11 +72,14 @@ const mergeChildren = ({
     };
 
     if (entering.has(child.key as string)) {
+      // If child is entering
       newChildProps.initialPose = preEnterPose;
-      newChildProps._pose = enterPose;
+      newChildProps._pose = enterPose; // TODO: Remove _pose and merge with child.props.pose
     } else if (moving.has(child.key as string) && flipMove) {
+      // If child is moving and we're using `flip`
       newChildProps._pose = [enterPose, 'flip'];
     } else {
+      // If child is moving
       newChildProps._pose = enterPose;
     }
 
@@ -86,7 +93,7 @@ const mergeChildren = ({
       onPoseComplete: removeFromTree(key),
       popFromFlow: flipMove,
       ...propsForChild,
-      ...filterChildProps(child.props)
+      ...filterChildProps(child.props, Object.keys(propsForChild))
     });
 
     const insertionIndex = prevKeys.indexOf(key);

--- a/packages/react-pose/src/components/Transition/index.tsx
+++ b/packages/react-pose/src/components/Transition/index.tsx
@@ -18,12 +18,10 @@ class Transition extends React.Component<Props, State> {
 
   static getDerivedStateFromProps = (
     props: Props,
-    { isLeaving, removeFromTree, displayedChildren }: State
+    { isLeaving, removeFromTree, children }: State
   ) => {
-    const incomingChildren = makeChildList(props.children);
-
     const {
-      children,
+      children: groupChildren,
       preEnterPose,
       enterPose,
       exitPose,
@@ -32,21 +30,23 @@ class Transition extends React.Component<Props, State> {
       ...propsForChild,
     } = props;
 
+    const incomingChildren = makeChildList(groupChildren);
+
     if (process.env.NODE_ENV !== 'production') {
       warning(!propsForChild.onPoseComplete, '<Transition/> (or <PoseGroup/>) doesn\'t accept onPoseComplete prop.')
     }
 
-    const displayedChildren = handleIncomingChildren({
+    const currentChildren = handleIncomingChildren({
       incomingChildren,
-      displayedChildren,
+      children,
       isLeaving,
       removeFromTree,
       groupProps: props
     })
 
     return {
-      displayedChildren: displayedChildren,
-      displayedChildrenWithGroupProps: displayedChildren.map(child =>
+      children: currentChildren,
+      displayedChildren: currentChildren.map(child =>
         // avoid extra copying in cloneElement
         React.createElement(child.type, {
           ...propsForChild,
@@ -67,11 +67,11 @@ class Transition extends React.Component<Props, State> {
   };
 
   removeFromChildren(key: string) {
-    const { displayedChildren, displayedChildrenWithGroupProps } = this.state;
+    const { children, displayedChildren } = this.state;
 
     this.setState({
+      children: removeFromChildren(children, key)
       displayedChildren: removeFromChildren(displayedChildren, key)
-      displayedChildrenWithGroupProps: removeFromChildren(displayedChildrenWithGroupProps, key)
     });
   }
 
@@ -80,7 +80,7 @@ class Transition extends React.Component<Props, State> {
   }
 
   render() {
-    return <Fragment>{this.state.displayedChildrenWithGroupProps}</Fragment>;
+    return <Fragment>{this.state.displayedChildren}</Fragment>;
   }
 }
 

--- a/packages/react-pose/src/components/Transition/types.ts
+++ b/packages/react-pose/src/components/Transition/types.ts
@@ -11,7 +11,8 @@ export type Props = {
 };
 
 export type State = {
-  children?: Array<React.ReactElement<any>>;
+  displayedChildren?: Array<React.ReactElement<any>>;
+  displayedChildrenWithGroupProps?: Array<React.ReactElement<any>>;
   incomingChildren?: Array<React.ReactElement<any>>;
   isLeaving: Set<string>;
   removeFromTree: (key: string) => void;

--- a/packages/react-pose/src/components/Transition/types.ts
+++ b/packages/react-pose/src/components/Transition/types.ts
@@ -11,16 +11,16 @@ export type Props = {
 };
 
 export type State = {
+  children?: Array<React.ReactElement<any>>;
   displayedChildren?: Array<React.ReactElement<any>>;
-  displayedChildrenWithGroupProps?: Array<React.ReactElement<any>>;
   incomingChildren?: Array<React.ReactElement<any>>;
   isLeaving: Set<string>;
   removeFromTree: (key: string) => void;
 };
 
 export interface MergeChildrenProps {
+  children: Array<React.ReactElement<any>>;
   incomingChildren: Array<React.ReactElement<any>>;
-  displayedChildren: Array<React.ReactElement<any>>;
   isLeaving: Set<string>;
   removeFromTree: (key: string) => void;
   groupProps: Props;

--- a/packages/react-pose/src/utils/object-assign.ts
+++ b/packages/react-pose/src/utils/object-assign.ts
@@ -10,3 +10,14 @@ export const pickAssign = (shouldPick: TestString, sources: Props[]) =>
     }
     return picked;
   }, {});
+
+export const filterBy = (obj: Props, keys: string[]) =>
+  Object.keys(obj)
+    .filter(key => keys.indexOf(key) === -1)
+    .reduce(
+      (acc, key) => {
+        acc[key] = obj[key];
+        return acc;
+      },
+      {} as Props
+    );


### PR DESCRIPTION
**I have not tested this yet at all**, please review the code/approach itself - hopefully also tests will be able to validate my logic here.

Additional benefit of this approach is that children during initial mount are also receiving group props now - which was not true before, only merged children (so subsequent renders) received them.