### PR TITLE
fix(IE11): Convert Map constructor to a set call

### DIFF
--- a/packages/animated-pose/src/inc/default-transitions.ts
+++ b/packages/animated-pose/src/inc/default-transitions.ts
@@ -37,4 +37,7 @@ const intelligentTransition = {
   default: tween
 };
 
-export default new Map([['default', intelligentTransition]]);
+const defaultTransitions = new Map();
+defaultTransitions.set('default', intelligentTransition);
+
+export default defaultTransitions;

--- a/packages/animated-pose/src/inc/default-transitions.ts
+++ b/packages/animated-pose/src/inc/default-transitions.ts
@@ -37,7 +37,5 @@ const intelligentTransition = {
   default: tween
 };
 
-const defaultTransitions = new Map();
-defaultTransitions.set('default', intelligentTransition);
-
-export default defaultTransitions;
+// IE11 doesn't support `new Map(iterable)`, Map.prototype.set returns the map itself
+export default new Map().set('default', intelligentTransition)


### PR DESCRIPTION
As [described here](https://github.com/mdn/browser-compat-data/pull/874), IE11 does not support passing in an array of tuples to the `Map` constructor. Changed this to use a generic constructor and `set` call instead.

Note: This is the only instance of this `Map` usage I could find except for the tests (which should be fine, since they don't run in IE11), but it wasn't an exhaustive search. Might need a more thorough look over.