### PR TITLE
Remove excessive window guard

### DIFF
--- a/packages/stylefire/src/index.ts
+++ b/packages/stylefire/src/index.ts
@@ -15,7 +15,7 @@ const createDOMStyler = (node: Element | Window, props: Props) => {
     styler = css(node, props);
   } else if (node instanceof SVGElement) {
     styler = svg(node);
-  } else if (typeof window !== 'undefined' && node === window) {
+  } else if (node === window) {
     styler = viewport(node);
   }
 


### PR DESCRIPTION
migrated https://github.com/Popmotion/stylefire/pull/22

> No other `window` usage is guarded, also some other browser specific globals (like `HTMLElement`) are not guarded which tells me this is not intended to run in non-browser environment at all and thus this single check can be safely removed.