### PR TITLE
Updated calc.stepProgress() to properly round around step border cases.

### DIFF
--- a/packages/popmotion/CHANGELOG.md
+++ b/packages/popmotion/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Popmotion adheres to [Semantic Versioning](http://semver.org/).
 
+## [8.3.8] 2018-08-30
+
+### Fixed
+
+- Calling `transform.steps()` should round properly to each step. [#528](https://github.com/Popmotion/popmotion/issues/528)
+
 ## [8.4.0] 2018-09-21
 
 ### Updated

--- a/packages/popmotion/src/_tests/calc.test.ts
+++ b/packages/popmotion/src/_tests/calc.test.ts
@@ -101,4 +101,13 @@ describe('stepProgress', () => {
     expect(stepProgress(3, .9)).toBe(1);
     expect(stepProgress(3, .1)).toBe(0);
   });
+  
+  it('should return the correct progress 0 - 1 on border boundaries', () => {
+    expect(stepProgress(3, 0)).toBe(0);
+    expect(stepProgress(3, .24)).toBe(0);
+    expect(stepProgress(3, .25)).toBe(.5);
+    expect(stepProgress(3, .74)).toBe(.5);
+    expect(stepProgress(3, .75)).toBe(1);
+    expect(stepProgress(3, 1)).toBe(1);
+  });
 });

--- a/packages/popmotion/src/calc.ts
+++ b/packages/popmotion/src/calc.ts
@@ -191,8 +191,10 @@ export const speedPerSecond = (velocity: number, frameDuration: number) =>
 */
 export const stepProgress = (steps: number, progress: number) => {
   const segment = 1 / (steps - 1);
-  const target = 1 - (1 / steps);
-  const progressOfTarget = Math.min(progress / target, 1);
+  const subsegment = 1 / (2 * (steps - 1)); 
+  const percentProgressOfTarget = Math.min(progress, 1);
+  const subsegmentProgressOfTarget = percentProgressOfTarget / subsegment;
+  const segmentProgressOfTarget = Math.floor((subsegmentProgressOfTarget + 1) / 2);
 
-  return Math.floor(progressOfTarget / segment) * segment;
+  return segmentProgressOfTarget * segment;
 };


### PR DESCRIPTION
Fixes issue [#528](https://github.com/Popmotion/popmotion/issues/528).