### PR TITLE
Fix incorrect example (pressable -> focusable)

### DIFF
--- a/packages/popmotion-pose/docs/examples/react/event-focus.md
+++ b/packages/popmotion-pose/docs/examples/react/event-focus.md
@@ -11,8 +11,19 @@ To animate an element on focus, set `focusable: true` and a `focus` prop.
 ```javascript
 const config = {
   focusable: true,
-  init: { scale: 1 },
-  press: { scale: 0.8 }
+  init: {
+    color: '#aaa',
+    outlineWidth: '0px',
+    outlineOffset: '0px',
+    scale: 1
+  },
+  focus: {
+    color: '#000',
+    outlineWidth: '12px',
+    outlineOffset: '5px',
+    outlineColor: '#AB36FF',
+    scale: 1.2
+  }
 }
 ```
 

--- a/packages/popmotion-pose/docs/examples/react/event-focus.md
+++ b/packages/popmotion-pose/docs/examples/react/event-focus.md
@@ -16,4 +16,4 @@ const config = {
 }
 ```
 
-<CodeSandbox id="31n86p0jw6" />
+<CodeSandbox id="rlly2kryrn" />

--- a/packages/popmotion-pose/docs/examples/react/event-focus.md
+++ b/packages/popmotion-pose/docs/examples/react/event-focus.md
@@ -10,7 +10,7 @@ To animate an element on focus, set `focusable: true` and a `focus` prop.
 
 ```javascript
 const config = {
-  pressable: true,
+  focusable: true,
   init: { scale: 1 },
   press: { scale: 0.8 }
 }


### PR DESCRIPTION
I found incorrect doc.

Codesandbox sample is incorrect too but I can't fix it.
(If need codexandbox too, please close this issue)