### PR TITLE
remove inline code mark for TOC

### DIFF
--- a/packages/popmotion/docs/api/calc.md
+++ b/packages/popmotion/docs/api/calc.md
@@ -17,7 +17,7 @@ import { calc } from 'popmotion';
 
 ## Methods
 
-### `angle`
+### angle
 Calculate the angle between two 2D points, in degrees.
 
 `type Point = { x: number, y: number }`
@@ -30,7 +30,7 @@ const b = { x: 1, y: 1 };
 calc.angle(a, b); // 45
 ```
 
-### `degreesToRadians`
+### degreesToRadians
 Convert degrees to radians.
 
 `degreesToRadians(degrees: number)`
@@ -39,7 +39,7 @@ Convert degrees to radians.
 calc.degreesToRadians(45); // 0.7853981633974483
 ```
 
-### `dilate`
+### dilate
 Dilate the difference between two values.
 
 `dilate(a: number, b: number, dilation: number)`
@@ -49,7 +49,7 @@ calc.dilate(0, 80, .5); // 40
 calc.dilate(100, 200, 2); // 300
 ```
 
-### `distance`
+### distance
 Calculate the distance between 1D, 2D or 3D points.
 
 `type Point = { x: number, y: number, z?: number }`
@@ -62,7 +62,7 @@ calc.distance({ x: 0, y: 0 }, { x: 1, y: 1}); // 1.4142135623730951
 calc.distance({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 10 }); // 10
 ```
 
-### `getProgressFromValue`
+### getProgressFromValue
 Calculate a progress (0 - 1) from a value and range.
 
 `getProgressFromValue(min: number, max: number, value: number)`
@@ -72,7 +72,7 @@ calc.getProgressFromValue(0, 100, 50); // 0.5
 calc.getProgressFromValue(100, 200, 50); // -0.5
 ```
 
-### `getValueFromProgress`
+### getValueFromProgress
 Calculate a value from a progress (0 - 1) and range.
 
 `getValueFromProgress(min: number, max: number, value: number)`
@@ -82,7 +82,7 @@ calc.getValueFromProgress(100, 200, 0.5); // 150
 calc.getValueFromProgress(100, 200, -1); // 0
 ```
 
-### `pointFromAngleAndDistance`
+### pointFromAngleAndDistance
 Given an origin point, angle in degrees and distance, returns a new point.
 
 `pointFromAngleAndDistance(origin: Point, angle: number, distance: number)`
@@ -97,7 +97,7 @@ calc.pointFromAngleAndDistance({ x: 0, y: 0 }, 45, 100);
 */
 ```
 
-### `radiansToDegrees`
+### radiansToDegrees
 Convert radians to degrees.
 
 `radiansToDegrees(radians: number)`
@@ -106,17 +106,17 @@ Convert radians to degrees.
 calc.radiansToDegrees(0.7853981633974483); // 45
 ```
 
-### `smooth`
+### smooth
 Framerate-independent value smoothing.
 
 `smooth(newValue: number, oldValue: number, frameDuration: number, smoothing: number)`
 
-### `speedPerFrame`
+### speedPerFrame
 Convert speed per second into speed per frame.
 
 `speedPerFrame(speedPerSecond: number, frameDuration: number)`
 
-### `speedPerSecond`
+### speedPerSecond
 Convert speed per frame into speed per second.
 
 `speedPerSecond(speedPerFrame: number, frameDuration: number)`


### PR DESCRIPTION
Calcurate TOC is broken on https://popmotion.io/api/calc/ 

like this
![2018-09-30 12 22 35](https://user-images.githubusercontent.com/13282103/46252945-bd595480-c4ab-11e8-8a73-c2356cd6d31c.png)

It maybe occur use inline marking.

But sadly, I can't build document on local machine and couldn't check.
If this solution is invalid, please close this.

