### PR TITLE
Don't override child props with parent props when starting child anim…

### DIFF
--- a/packages/pose-core/src/factories/setter.ts
+++ b/packages/pose-core/src/factories/setter.ts
@@ -73,7 +73,6 @@ const startChildAnimations = <V, A, C, P>(
   Array.from(children).forEach((child, i) => {
     animations.push(
       child.set(next, {
-        ...props,
         delay: delay + generateStaggerDuration(i)
       })
     );


### PR DESCRIPTION
…ations

fixes #593

I'll write a test for this later, but I'm not sure if current fix is completely OK - was there any reason why those props were transferred here?

This is wrong because it unconditionally overrides child props with parent's and there are things such as `element`, `elementStyler` there that are used later in example in `applyValues` so they get applied on the wrong element.

I suspect that because this overrides child props then resolvers might get called with wrong values.