### PR TITLE
Fix issue with reusing stale children

### DIFF
--- a/packages/react-pose/src/_tests/index.test.tsx
+++ b/packages/react-pose/src/_tests/index.test.tsx
@@ -471,3 +471,33 @@ test('PoseGroup: special pre-enter pose', () => {
     expect(y).toBe(25);
   });
 });
+
+test('StrictMode: PoseGroup removes children correctly', () => {
+  return new Promise(resolve => {
+    const First = posed.div({
+      enter: { opacity: 1 },
+      exit: { opacity: 0 }
+    });
+
+    const Second = posed.div({
+      enter: { opacity: 1 },
+      exit: { opacity: 0 }
+    });
+
+    const Group = props => (<React.StrictMode><PoseGroup {...props} /></React.StrictMode>);
+
+    const { rerender } = render(
+      <Group>
+        <First
+          key="first"
+          onPoseComplete={pose => {
+            expect(pose).toBe('exit')
+            resolve()
+          }
+        />
+      </Group>
+    );
+
+    rerender(<Group><Second key="second"/></Group>);
+  });
+});

--- a/packages/react-pose/src/components/Transition/children.ts
+++ b/packages/react-pose/src/components/Transition/children.ts
@@ -43,7 +43,7 @@ const handleTransition = (
     displayedChildren,
     finishedLeaving,
     hasInitialized,
-    indexedChildren: prevChildren,
+    indexedChildren,
     scheduleChildRemoval,
   }: State
 ) => {
@@ -51,7 +51,6 @@ const handleTransition = (
 
   const nextState: Partial<State> = {
     displayedChildren: [],
-    indexedChildren: {},
   };
 
   if (process.env.NODE_ENV !== 'production') {
@@ -121,7 +120,7 @@ const handleTransition = (
     }
 
     const newChild = React.cloneElement(child, newChildProps);
-    nextState.indexedChildren[child.key] = newChild;
+    indexedChildren[child.key] = newChild;
     nextState.displayedChildren.push(
       hasPropsForChildren
         ? prependProps(newChild, propsForChildren)
@@ -130,8 +129,7 @@ const handleTransition = (
   });
 
   leaving.forEach(key => {
-    const child = prevChildren[key];
-
+    const child = indexedChildren[key];
     const newChild = newlyLeaving[key]
       ? React.cloneElement(child, {
           _pose: exitPose,
@@ -154,7 +152,7 @@ const handleTransition = (
     // TODO: Write a shitty algo
     // }
 
-    nextState.indexedChildren[child.key] = newChild;
+    indexedChildren[child.key] = newChild;
     nextState.displayedChildren.splice(
       insertionIndex,
       0,


### PR DESCRIPTION
Fixes https://github.com/Popmotion/popmotion/issues/601

The issue was that leaving was reusing stale children - because it came from state (immutable), when React has called getDerivatedStateFromProps twice the first run calculated nextChildren + indexedChildren correctly (trying to put them into state), but second run didnt receive those values because state wasnt updated yet. By mutating `indexedChildren` we fix that issue, making it safer to reuse previous calculations.