### PR TITLE
adding value types for padding, margin, and border

### DIFF
--- a/packages/stylefire/CHANGELOG.md
+++ b/packages/stylefire/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Stylefire adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.0] 2018-11-07
+
+### Added
+
+- Adding value types for `padding`, `margin`, and `border`.
+
 ## [2.1.0] 2018-09-21
 
 ### Updated

--- a/packages/stylefire/src/css/value-types.ts
+++ b/packages/stylefire/src/css/value-types.ts
@@ -22,19 +22,40 @@ const valueTypes: { [key: string]: ValueType } = {
   borderRightColor: color,
   borderBottomColor: color,
   borderLeftColor: color,
+  borderWidth: px,
+  borderTopWidth: px,
+  borderRightWidth: px,
+  borderBottomWidth: px,
+  borderLeftWidth: px,
   borderRadius: px,
+  borderTopLeftRadius: px,
+  borderTopRightRadius: px,
+  borderBottomRightRadius: px,
+  borderBottomLeftRadius: px,
 
-  // Positioning
+  // Positioning props
   width: px,
   maxWidth: px,
   height: px,
   maxHeight: px,
   top: px,
-  left: px,
-  bottom: px,
   right: px,
+  bottom: px,
+  left: px,
 
-  // Transform properties
+  // Spacing props
+  padding: px,
+  paddingTop: px,
+  paddingRight: px,
+  paddingBottom: px,
+  paddingLeft: px,
+  margin: px,
+  marginTop: px,
+  marginRight: px,
+  marginBottom: px,
+  marginLeft: px,
+
+  // Transform props
   rotate: degrees,
   rotateX: degrees,
   rotateY: degrees,


### PR DESCRIPTION
Adds value types for spacing props like `padding` and `margin`, as well as remaining `border` props.

Closes #615