### PR TITLE
Fixed issue with getSnapshotBeforeUpdate checking prevProps instead o…

### DIFF
--- a/packages/react-pose/src/components/PoseElement/index.tsx
+++ b/packages/react-pose/src/components/PoseElement/index.tsx
@@ -223,7 +223,8 @@ class PoseElement extends PureComponent<PoseElementInternalProps> {
     }
   }
 
-  getSnapshotBeforeUpdate({ pose, _pose }: PoseElementInternalProps): null {
+  getSnapshotBeforeUpdate(): null {
+    const { pose, _pose } = this.props;
     if (hasPose(pose, 'flip') || hasPose(_pose, 'flip')) this.poser.measure();
     return null;
   }


### PR DESCRIPTION
…f this.props

fixes #624 fixes #614

my dumb mistake when I've changed the lifecycle hook - `componentWillUpdate` was called with `nextProps` (having prevProps on `this.props`), with `getSnapshotBeforeUpdate` this is reversed - it's called with `prevProps` and having "nextProps" already on this as props

would love to write a test for this, but I have no idea how :s (except of checking the implementation details in test which I'd like to avoid)