### PR TITLE
Stylefire: Add graceful degradation for NS_ERROR_FAILURE errors in Firefox

### DIFF
--- a/packages/stylefire/src/svg/index.ts
+++ b/packages/stylefire/src/svg/index.ts
@@ -5,7 +5,7 @@ import { setDomAttrs } from '../styler/utils';
 import buildAttrs from './build';
 import getValueType from './value-types';
 import { SVGState } from './types';
-import { getSVGElementDimensionsSafely } from './utils';
+import { getSVGElementDimensions } from './utils';
 
 type SVGProps = {
   dimensions: {
@@ -37,7 +37,7 @@ const svgStyler = createStyler({
 });
 
 export default (element: SVGElement | SVGPathElement): Styler => {
-  const dimensions = getSVGElementDimensionsSafely(element);
+  const dimensions = getSVGElementDimensions(element);
 
   const props: SVGProps = {
     element,

--- a/packages/stylefire/src/svg/index.ts
+++ b/packages/stylefire/src/svg/index.ts
@@ -5,6 +5,7 @@ import { setDomAttrs } from '../styler/utils';
 import buildAttrs from './build';
 import getValueType from './value-types';
 import { SVGState } from './types';
+import { getSVGElementDimensionsSafely } from './utils';
 
 type SVGProps = {
   dimensions: {
@@ -36,14 +37,11 @@ const svgStyler = createStyler({
 });
 
 export default (element: SVGElement | SVGPathElement): Styler => {
-  const { x, y, width, height } =
-    typeof (element as SVGGraphicsElement).getBBox === 'function'
-      ? (element as SVGGraphicsElement).getBBox()
-      : (element.getBoundingClientRect() as DOMRect);
+  const dimensions = getSVGElementDimensionsSafely(element);
 
   const props: SVGProps = {
     element,
-    dimensions: { x, y, width, height },
+    dimensions,
     isPath: false
   };
 

--- a/packages/stylefire/src/svg/utils.ts
+++ b/packages/stylefire/src/svg/utils.ts
@@ -1,0 +1,36 @@
+import { Dimensions } from './types';
+
+/**
+ * Feature detection for getBBox call on an unrendered SVG Element.
+ * Firefox will throw "NS_ERROR_FAILURE" error.
+ * We want to detect this upfront so we do not crash in any future measurement.
+ */
+export const CAN_MEASURE_NOT_RENDERED_SVG_ELEMENTS = (() => {
+  try {
+    document.createElementNS('http://www.w3.org/2000/svg', 'rect').getBBox();
+  } catch (e) {
+    return false;
+  }
+  return true;
+})();
+
+export const getDimensions = (
+  element: SVGElement | SVGPathElement
+): Dimensions =>
+  typeof (element as SVGGraphicsElement).getBBox === 'function'
+    ? (element as SVGGraphicsElement).getBBox()
+    : (element.getBoundingClientRect() as DOMRect);
+
+export const getSVGElementDimensionsSafely = (
+  element: SVGElement | SVGPathElement
+): Dimensions => {
+  if (CAN_MEASURE_NOT_RENDERED_SVG_ELEMENTS) {
+    return getDimensions(element);
+  }
+  try {
+    return getDimensions(element);
+  } catch (e) {
+    // most likely trying to measure an unrendered element under Firefox
+    return { x: 0, y: 0, width: 0, height: 0 };
+  }
+};

--- a/packages/stylefire/src/svg/utils.ts
+++ b/packages/stylefire/src/svg/utils.ts
@@ -21,7 +21,7 @@ export const getDimensions = (
     ? (element as SVGGraphicsElement).getBBox()
     : (element.getBoundingClientRect() as DOMRect);
 
-export const getSVGElementDimensionsSafely = (
+export const getSVGElementDimensions = (
   element: SVGElement | SVGPathElement
 ): Dimensions => {
   if (CAN_MEASURE_NOT_RENDERED_SVG_ELEMENTS) {

--- a/packages/stylefire/src/svg/utils.ts
+++ b/packages/stylefire/src/svg/utils.ts
@@ -1,19 +1,5 @@
 import { Dimensions } from './types';
 
-/**
- * Feature detection for getBBox call on an unrendered SVG Element.
- * Firefox will throw "NS_ERROR_FAILURE" error.
- * We want to detect this upfront so we do not crash in any future measurement.
- */
-export const CAN_MEASURE_NOT_RENDERED_SVG_ELEMENTS = (() => {
-  try {
-    document.createElementNS('http://www.w3.org/2000/svg', 'rect').getBBox();
-  } catch (e) {
-    return false;
-  }
-  return true;
-})();
-
 export const getDimensions = (
   element: SVGElement | SVGPathElement
 ): Dimensions =>
@@ -21,12 +7,14 @@ export const getDimensions = (
     ? (element as SVGGraphicsElement).getBBox()
     : (element.getBoundingClientRect() as DOMRect);
 
+/**
+ * The getBBox call on an unrendered SVG Element crashes Firefox.
+ * It throws an "NS_ERROR_FAILURE" error. We want to catch this upfront.
+ * Animating Rotation and Scale of these SVG Elements might be broken in such cases.
+ */
 export const getSVGElementDimensions = (
   element: SVGElement | SVGPathElement
 ): Dimensions => {
-  if (CAN_MEASURE_NOT_RENDERED_SVG_ELEMENTS) {
-    return getDimensions(element);
-  }
   try {
     return getDimensions(element);
   } catch (e) {


### PR DESCRIPTION
Trying to create a `Styler` on a not rendered SVG Element under Firefox currently results in a hard failure:

```
[Exception... "Failure"  nsresult: "0x80004005 (NS_ERROR_FAILURE)"]
```

The affected `Element`s may be nested under `mask`s, `clipPaths` or ones with effective `display: none` style.

Since there's no reliable way to determine if an element is currently rendered (or not), I've opted for feature detection. If we detect that we cannot measure a not rendered SVG Element (`getBBox()`), we wrap that call in a try/catch (i.e. only in Firefox, so we do not cause a performance regression in other browsers).

An alternative solution to the try/catch is to check if the SVG Element is a (grand)child of an unsupported Element, like this (only `clipPath` below):

```js
/**
 * in Firefox, when element is inside a <clipPath> Element
 * running element.getBBox() will throw an "NS_ERROR_FAILURE" error
 */
export const isInsideClipPath = (element: SVGElement | SVGPathElement) => {
  const { ownerSVGElement } = element;
  if (!ownerSVGElement) return false;
  let parentElement: SVGElement | HTMLElement | null = element;
  while (parentElement && parentElement !== ownerSVGElement) {
    if (parentElement.tagName === 'clipPath') return true;
    parentElement = (element.parentElement as SVGElement | HTMLElement | null);
  }
  return false;
}
```

But I think this adds complexity and won't work in all cases anyway (detecting `display: none` is very hard). `try/catch` shouldn't be too expensive in modern browsers anyway.

This mostly fixes the issue, however in some cases it might work differently across browsers, since we do not get the actual `x`/`y` values.

I didn't add tests since there's actually no way to meaningfully test this without running Firefox.

Solves: #174, #179.