### PR TITLE
Transition map factory fix

### DIFF
--- a/packages/animated-pose/src/factory.ts
+++ b/packages/animated-pose/src/factory.ts
@@ -13,7 +13,9 @@ import {
   AnimatedPoserFactory,
   Layout
 } from './types';
-import convertTransitionDefinition from './inc/convert-transition-definition';
+import convertTransitionDefinition, {
+  TransitionConfig
+} from './inc/convert-transition-definition';
 
 const FLIP_TO_ORIGIN = 'flipToOrigin';
 
@@ -46,7 +48,8 @@ export default ({
     Value,
     Action,
     Action,
-    AnimatedPoser
+    AnimatedPoser,
+    TransitionConfig
   >({
     /**
      * Bind onChange callbacks
@@ -104,7 +107,9 @@ export default ({
             `useNativeDriver is invalidated on value "${passiveParentKey}", because interpolated value "${key}" can't be animated by the native driver.`
           );
         }
-        return { interpolation: passiveParent.raw.interpolate(passiveProps) };
+        return {
+          interpolation: passiveParent.raw.interpolate(passiveProps)
+        };
       } else {
         let needsInterpolation = false;
         let unit = '';

--- a/packages/popmotion-pose/package.json
+++ b/packages/popmotion-pose/package.json
@@ -52,6 +52,7 @@
     "popmotion": "^8.5.0",
     "pose-core": "^2.0.0",
     "style-value-types": "^3.0.6",
+    "ts-essentials": "^1.0.3",
     "tslib": "^1.9.1"
   },
   "unpkg": "./dist/popmotion-pose.js",

--- a/packages/popmotion-pose/src/factories/pose.ts
+++ b/packages/popmotion-pose/src/factories/pose.ts
@@ -110,7 +110,7 @@ const pose = <P>({
   readValueFromSource,
   posePriority,
   setValueNative
-}: PopmotionPoserFactoryConfig<P>) =>
+}: PopmotionPoserFactoryConfig<P, TransitionDefinition>) =>
   poseFactory<Value, Action, ColdSubscription, P, TransitionDefinition>({
     bindOnChange: (values, onChange) => key => {
       if (!values.has(key)) return;

--- a/packages/popmotion-pose/src/factories/pose.ts
+++ b/packages/popmotion-pose/src/factories/pose.ts
@@ -1,9 +1,4 @@
 import {
-  spring,
-  tween,
-  decay,
-  keyframes,
-  physics,
   value,
   chain,
   easing,
@@ -17,11 +12,14 @@ import {
   TransitionProps,
   Transformer,
   PopmotionPoserFactoryConfig,
-  AnimationDef
+  TransitionDefinition,
+  CubicBezierArgs
 } from '../types';
 import defaultTransitions, { just } from '../inc/default-transitions';
+import { animationLookup, easingLookup } from '../inc/lookups';
 import { getValueType } from '../inc/value-types';
 import { invariant } from 'hey-listen';
+import { Easing } from '@popmotion/easing';
 export { Poser };
 
 const createPassiveValue = (
@@ -45,49 +43,15 @@ const createValue = (init: any) => {
 const addActionDelay = (delay = 0, transition: Action) =>
   chain(delayAction(delay), transition);
 
-const animationLookup: {
-  [key: string]: (props: { [key: string]: any }) => Action;
-} = {
-  tween,
-  spring,
-  decay,
-  keyframes,
-  physics
-};
-
-const {
-  linear,
-  easeIn,
-  easeOut,
-  easeInOut,
-  circIn,
-  circOut,
-  circInOut,
-  backIn,
-  backOut,
-  backInOut,
-  anticipate
-} = easing;
-
-const easingLookup: { [key: string]: (num: number) => number } = {
-  linear,
-  easeIn,
-  easeOut,
-  easeInOut,
-  circIn,
-  circOut,
-  circInOut,
-  backIn,
-  backOut,
-  backInOut,
-  anticipate
-};
+const isCubicBezierArgs = (
+  args: Easing[] | CubicBezierArgs
+): args is CubicBezierArgs => typeof args[0] === 'number';
 
 // At the moment this function just uses `type` as a key - in the future
 // we could infer the animation type based on the properties being provided
 const getAction = (
   v: Value,
-  { type = 'tween', ease, ...def }: AnimationDef,
+  { type = 'tween', ease: definedEase, ...def }: TransitionDefinition,
   { from, to, velocity }: TransitionProps
 ) => {
   invariant(
@@ -95,28 +59,33 @@ const getAction = (
     `Invalid transition type '${type}'. Valid transition types are: tween, spring, decay, physics and keyframes.`
   );
 
+  let ease: Exclude<
+    typeof definedEase,
+    keyof typeof easingLookup | CubicBezierArgs
+  >;
+
   // Convert ease definition into easing function
   if (type === 'tween') {
-    const typeOfEase = typeof ease;
-    if (typeOfEase !== 'function') {
-      if (typeOfEase === 'string') {
+    if (typeof definedEase !== 'function') {
+      if (typeof definedEase === 'string') {
         invariant(
-          easingLookup[ease] !== undefined,
-          `Invalid easing type '${ease}'. popmotion.io/pose/api/config`
+          easingLookup[definedEase] !== undefined,
+          `Invalid easing type '${definedEase}'. popmotion.io/pose/api/config`
         );
 
-        ease = easingLookup[ease];
-      } else if (Array.isArray(ease)) {
+        ease = easingLookup[definedEase];
+      } else if (Array.isArray(definedEase) && isCubicBezierArgs(definedEase)) {
         invariant(
-          ease.length === 4,
+          definedEase.length === 4,
           `Cubic bezier arrays must contain four numerical values.`
         );
-
-        const [x1, y1, x2, y2] = ease;
+        const [x1, y1, x2, y2] = definedEase;
         ease = easing.cubicBezier(x1, y1, x2, y2);
       }
     }
   }
+
+  ease = ease || (definedEase as typeof ease);
 
   const baseProps =
     type !== 'keyframes'
@@ -208,9 +177,9 @@ const pose = <P>({
 
     convertTransitionDefinition: (
       val,
-      def: AnimationDef | Action,
+      def: TransitionDefinition | Action,
       props: TransitionProps
-    ) => {
+    ): Action => {
       if (isAction(def)) return def;
 
       const { delay, min, max, round, ...remainingDef } = def;

--- a/packages/popmotion-pose/src/factories/pose.ts
+++ b/packages/popmotion-pose/src/factories/pose.ts
@@ -111,7 +111,7 @@ const pose = <P>({
   posePriority,
   setValueNative
 }: PopmotionPoserFactoryConfig<P>) =>
-  poseFactory<Value, Action, ColdSubscription, P>({
+  poseFactory<Value, Action, ColdSubscription, P, TransitionDefinition>({
     bindOnChange: (values, onChange) => key => {
       if (!values.has(key)) return;
 
@@ -176,7 +176,7 @@ const pose = <P>({
     getInstantTransition: (_, { to }) => just(to),
 
     convertTransitionDefinition: (
-      val,
+      val: Value,
       def: TransitionDefinition | Action,
       props: TransitionProps
     ): Action => {

--- a/packages/popmotion-pose/src/inc/default-transitions.ts
+++ b/packages/popmotion-pose/src/inc/default-transitions.ts
@@ -1,7 +1,11 @@
 import { spring, tween, action, pointer, transform, Action } from 'popmotion';
 import { linear } from '@popmotion/easing';
 import { TransitionMap } from 'pose-core';
-import { Transition, BoundingBoxDimension } from '../types';
+import {
+  Transition,
+  BoundingBoxDimension,
+  TransitionDefinition
+} from '../types';
 import { percent } from 'style-value-types';
 import { resolveProp } from '../dom/utils';
 const { interpolate } = transform;
@@ -93,7 +97,7 @@ const linearTween: Transition = ({ from, to }) =>
   tween({ from, to, ease: linear });
 
 // TODO: Adjust transitions based on behavioural props
-const intelligentTransition: TransitionMap<Action> = {
+const intelligentTransition: TransitionMap<Action, TransitionDefinition> = {
   x: underDampedSpring,
   y: underDampedSpring,
   z: underDampedSpring,
@@ -108,7 +112,7 @@ const intelligentTransition: TransitionMap<Action> = {
   default: tween
 };
 
-const dragAction: TransitionMap<Action> = {
+const dragAction: TransitionMap<Action, TransitionDefinition> = {
   ...intelligentTransition,
   x: createPointer(pointerX, 'left', 'right', BoundingBoxDimension.width),
   y: createPointer(pointerY, 'top', 'bottom', BoundingBoxDimension.height)
@@ -116,13 +120,13 @@ const dragAction: TransitionMap<Action> = {
 
 // TODO: Return `decay` based on behavioural props
 const justAxis: Transition = ({ from }) => just(from);
-const intelligentDragEnd: TransitionMap<Action> = {
+const intelligentDragEnd: TransitionMap<Action, TransitionDefinition> = {
   ...intelligentTransition,
   x: justAxis,
   y: justAxis
 };
 
-export default new Map<string, Transition | TransitionMap<Action>>([
+export default new Map<string, TransitionMap<Action, TransitionDefinition>>([
   ['default', intelligentTransition],
   ['drag', dragAction],
   ['dragEnd', intelligentDragEnd]

--- a/packages/popmotion-pose/src/inc/lookups.ts
+++ b/packages/popmotion-pose/src/inc/lookups.ts
@@ -1,0 +1,47 @@
+import {
+  spring,
+  tween,
+  decay,
+  keyframes,
+  physics,
+  easing,
+  Action
+} from 'popmotion';
+
+export const animationLookup: {
+  [key: string]: (props: { [key: string]: any }) => Action;
+} = {
+  tween,
+  spring,
+  decay,
+  keyframes,
+  physics
+};
+
+const {
+  linear,
+  easeIn,
+  easeOut,
+  easeInOut,
+  circIn,
+  circOut,
+  circInOut,
+  backIn,
+  backOut,
+  backInOut,
+  anticipate
+} = easing;
+
+export const easingLookup = {
+  linear,
+  easeIn,
+  easeOut,
+  easeInOut,
+  circIn,
+  circOut,
+  circInOut,
+  backIn,
+  backOut,
+  backInOut,
+  anticipate
+};

--- a/packages/popmotion-pose/src/types.ts
+++ b/packages/popmotion-pose/src/types.ts
@@ -27,8 +27,8 @@ export type Value = {
   type?: ValueType;
 };
 
-export type Pose = Pose<Action>;
-export type PoseMap = PoseMap<Action>;
+export type Pose = Pose<Action, TransitionDefinition>;
+export type PoseMap = PoseMap<Action, TransitionDefinition>;
 
 export type PoserState = PoserState<
   Value,
@@ -75,9 +75,9 @@ export type DomPopmotionConfig = {
 
 export type Draggable = boolean | 'x' | 'y';
 
-export type PopmotionPoserFactoryConfig<P> = {
+export type PopmotionPoserFactoryConfig<P, TD> = {
   extendAPI: ExtendAPI<Value, Action, ColdSubscription, P>;
-  transformPose: TransformPose<Value, Action, ColdSubscription, P>;
+  transformPose: TransformPose<Value, Action, ColdSubscription, P, TD>;
   addListenerToValue: (key: string, styler: Styler) => (v: any) => void;
   readValueFromSource?: ReadValueFromSource;
   posePriority?: string[];

--- a/packages/popmotion-pose/src/types.ts
+++ b/packages/popmotion-pose/src/types.ts
@@ -1,5 +1,14 @@
 import { ValueType } from 'style-value-types';
-import { Action, ValueReaction, ColdSubscription } from 'popmotion';
+import {
+  Action,
+  ValueReaction,
+  ColdSubscription,
+  TweenProps,
+  PhysicsProps,
+  SpringProps,
+  DecayProps,
+  KeyframesProps
+} from 'popmotion';
 import { Poser, PoserConfig } from 'pose-core';
 import {
   Pose,
@@ -10,6 +19,8 @@ import {
   ReadValueFromSource
 } from 'pose-core';
 import { Styler } from 'stylefire';
+import { Merge } from 'ts-essentials';
+import { easingLookup } from './inc/lookups';
 
 export type Value = {
   raw: ValueReaction;
@@ -99,11 +110,52 @@ export enum BoundingBoxDimension {
   bottom = 'bottom'
 }
 
-export type AnimationDef = {
-  type: 'tween' | 'physics' | 'spring' | 'decay' | 'keyframes';
+// it's needed in order to destructure `ease` property in `getAction`
+type NoEase = { ease?: undefined };
+
+export type CubicBezierArgs = [number, number, number, number];
+
+type TransitionDefinitionCommonProps = {
+  delay?: number;
   min?: number;
   max?: number;
-  delay?: number;
   round?: boolean;
-  [key: string]: any;
 };
+
+export type DecayDefinition = {
+  type: 'decay';
+} & TransitionDefinitionCommonProps &
+  DecayProps &
+  NoEase;
+export type KeyframesDefinition = {
+  type: 'keyframes';
+} & TransitionDefinitionCommonProps &
+  KeyframesProps;
+export type PhysicsDefinition = {
+  type: 'physics';
+} & TransitionDefinitionCommonProps &
+  PhysicsProps &
+  NoEase;
+export type SpringDefinition = {
+  type: 'spring';
+} & TransitionDefinitionCommonProps &
+  SpringProps &
+  NoEase;
+export type TweenDefinition = Merge<
+  { type: 'tween' } & TransitionDefinitionCommonProps & TweenProps,
+  {
+    ease: TweenProps['ease'] | keyof typeof easingLookup | CubicBezierArgs;
+  }
+>;
+
+export type TransitionDefinition =
+  | TweenDefinition
+  | PhysicsDefinition
+  | SpringDefinition
+  | DecayDefinition
+  | KeyframesDefinition;
+
+/**
+ * @deprecated Use TransitionDefinition
+ */
+export type AnimationDef = TransitionDefinition;

--- a/packages/popmotion/src/animations/decay/index.ts
+++ b/packages/popmotion/src/animations/decay/index.ts
@@ -4,9 +4,9 @@ import { number } from 'style-value-types';
 import action from '../../action';
 import { Action } from '../../action';
 import vectorAction, { ActionFactory } from '../../action/vector';
-import { Props } from './types';
+import { DecayProps } from './types';
 
-const decay = (props: Props = {}): Action =>
+const decay = (props: DecayProps = {}): Action =>
   action(({ complete, update }) => {
     const {
       velocity = 0,

--- a/packages/popmotion/src/animations/decay/types.ts
+++ b/packages/popmotion/src/animations/decay/types.ts
@@ -1,10 +1,10 @@
 export type ModifyTarget = (v: number) => number;
 
-export type Props = {
-  velocity?: number,
-  from?: number,
-  modifyTarget?: ModifyTarget,
-  power?: number,
-  timeConstant?: number,
-  restDelta?: number
+export type DecayProps = {
+  velocity?: number;
+  from?: number;
+  modifyTarget?: ModifyTarget;
+  power?: number;
+  timeConstant?: number;
+  restDelta?: number;
 };

--- a/packages/popmotion/src/animations/keyframes/index.ts
+++ b/packages/popmotion/src/animations/keyframes/index.ts
@@ -4,7 +4,7 @@ import { clamp, progress } from '@popmotion/popcorn';
 import { Update } from '../../observer/types';
 import tween from '../tween';
 import scrubber from '../tween/scrubber';
-import { KeyframeProps } from './types';
+import { KeyframesProps } from './types';
 
 const clampProgress = clamp(0, 1);
 
@@ -64,7 +64,7 @@ const keyframes = ({
   times,
   values,
   ...tweenProps
-}: KeyframeProps): Action => {
+}: KeyframesProps): Action => {
   easings = Array.isArray(easings)
     ? easings
     : defaultEasings(values as number[], easings);

--- a/packages/popmotion/src/animations/keyframes/types.ts
+++ b/packages/popmotion/src/animations/keyframes/types.ts
@@ -1,21 +1,21 @@
 import { Easing } from '@popmotion/easing';
 
 export type ValueMap = {
-  [key: string]: string | number
+  [key: string]: string | number;
 };
 
-export type ValueList = string|number[];
+export type ValueList = string | number[];
 
 export type Values = number[] | string[] | ValueMap[] | ValueList[];
 
-export type KeyframeProps = {
-  values: Values,
-  times?: number[],
-  ease?: Easing | Easing[] | { [key: string]: Easing },
-  easings?: Easing[],
-  elapsed?: number,
-  duration?: number,
-  loop?: number,
-  flip?: number,
-  yoyo?: number
+export type KeyframesProps = {
+  values: Values;
+  times?: number[];
+  ease?: Easing | Easing[] | { [key: string]: Easing };
+  easings?: Easing[];
+  elapsed?: number;
+  duration?: number;
+  loop?: number;
+  flip?: number;
+  yoyo?: number;
 };

--- a/packages/popmotion/src/animations/physics/index.ts
+++ b/packages/popmotion/src/animations/physics/index.ts
@@ -4,9 +4,9 @@ import action from '../../action';
 import { Action } from '../../action';
 import vectorAction, { ActionFactory } from '../../action/vector';
 import { speedPerFrame } from '../../calc';
-import { PhysicsInterface, Props } from './types';
+import { PhysicsInterface, PhysicsProps } from './types';
 
-const physics = (props: Props = {}): Action =>
+const physics = (props: PhysicsProps = {}): Action =>
   action(
     ({ complete, update }): PhysicsInterface => {
       let {

--- a/packages/popmotion/src/animations/physics/types.ts
+++ b/packages/popmotion/src/animations/physics/types.ts
@@ -1,11 +1,11 @@
-export type Props = {
-  from?: number,
-  acceleration?: number,
-  friction?: number,
-  velocity?: number,
-  restSpeed?: number | false,
-  springStrength?: number,
-  to?: number
+export type PhysicsProps = {
+  from?: number;
+  to?: number;
+  acceleration?: number;
+  friction?: number;
+  velocity?: number;
+  restSpeed?: number | false;
+  springStrength?: number;
 };
 
 export type PhysicsInterface = {

--- a/packages/popmotion/src/animations/timeline/index.ts
+++ b/packages/popmotion/src/animations/timeline/index.ts
@@ -1,7 +1,12 @@
 import { Action } from '../../action';
-import { AnimationDefinition, Instruction, Tracks, TrackActions } from './types';
+import {
+  AnimationDefinition,
+  Instruction,
+  Tracks,
+  TrackActions
+} from './types';
 import keyframes from '../keyframes';
-import { KeyframeProps } from '../keyframes/types';
+import { KeyframesProps } from '../keyframes/types';
 import { easeInOut, linear } from '@popmotion/easing';
 import composite from '../../compositors/composite';
 import { TweenProps } from '../tween/types';
@@ -23,7 +28,8 @@ const flattenTimings = (instructions: Instruction[]) => {
     flatInstructions.push(item);
 
     if (i !== numSegments - 1) {
-      const duration = (item as AnimationDefinition).duration || DEFAULT_DURATION;
+      const duration =
+        (item as AnimationDefinition).duration || DEFAULT_DURATION;
       offset += staggerDelay as number;
       flatInstructions.push(`-${duration - offset}`);
     }
@@ -32,7 +38,10 @@ const flattenTimings = (instructions: Instruction[]) => {
   return flatInstructions;
 };
 
-const flattenArrayInstructions = (instructions: Instruction[], instruction: Instruction) => {
+const flattenArrayInstructions = (
+  instructions: Instruction[],
+  instruction: Instruction
+) => {
   Array.isArray(instruction)
     ? instructions.push(...flattenTimings(instruction))
     : instructions.push(instruction);
@@ -40,7 +49,11 @@ const flattenArrayInstructions = (instructions: Instruction[], instruction: Inst
   return instructions;
 };
 
-const convertDefToProps = (props: KeyframeProps, def: AnimationDefinition, i: number) => {
+const convertDefToProps = (
+  props: KeyframesProps,
+  def: AnimationDefinition,
+  i: number
+) => {
   const { duration, easings, times, values } = props;
   const numValues = values.length;
   const prevTimeTo = times[numValues - 1];
@@ -51,7 +64,6 @@ const convertDefToProps = (props: KeyframeProps, def: AnimationDefinition, i: nu
   if (i === 0) {
     (values as Value[]).push(def.from);
     times.push(timeFrom);
-
   } else {
     // If we need to patch an interim tween
     if (prevTimeTo !== timeFrom) {
@@ -65,7 +77,6 @@ const convertDefToProps = (props: KeyframeProps, def: AnimationDefinition, i: nu
       (values as Value[]).push(from);
       times.push(timeFrom);
       easings.push(linear);
-
     } else if (def.from !== undefined) {
       (values as Value[]).push(def.from);
       times.push(timeFrom);
@@ -97,19 +108,20 @@ const timeline = (
     if (typeof instruction === 'string') {
       playhead += parseFloat(instruction);
 
-    // If absolute timestamp
+      // If absolute timestamp
     } else if (typeof instruction === 'number') {
       playhead = instruction;
 
-    // If animation definition, apply playhead
+      // If animation definition, apply playhead
     } else {
       const def: AnimationDefinition = {
-        ...instruction as AnimationDefinition,
+        ...(instruction as AnimationDefinition),
         at: playhead
       };
 
       // TODO: Apply defaults in a cleaner fashion
-      def.duration = def.duration === undefined ? DEFAULT_DURATION : def.duration;
+      def.duration =
+        def.duration === undefined ? DEFAULT_DURATION : def.duration;
 
       animationDefs.push(def);
       playhead += def.duration;

--- a/packages/popmotion/src/index.ts
+++ b/packages/popmotion/src/index.ts
@@ -70,7 +70,11 @@ import * as valueTypes from 'style-value-types';
 export { valueTypes };
 
 // Types
-import { Action } from './action';
-import { ColdSubscription } from './action/types';
-import { ValueReaction } from './reactions/value';
-export { Action, ColdSubscription, ValueReaction };
+export { Action } from './action';
+export { ColdSubscription } from './action/types';
+export { DecayProps } from './animations/decay/types';
+export { KeyframesProps } from './animations/keyframes/types';
+export { PhysicsProps } from './animations/physics/types';
+export { SpringProps } from './animations/spring/types';
+export { TweenProps } from './animations/tween/types';
+export { ValueReaction } from './reactions/value';

--- a/packages/pose-core/src/_tests/index.test.ts
+++ b/packages/pose-core/src/_tests/index.test.ts
@@ -27,7 +27,7 @@ const mockMultiplyAction = (to, multiply): Action => ({
 
 const mockActionInverse = (to): Action => ({
   start: (value, complete): Subscription => {
-    value.i = - to;
+    value.i = -to;
     complete();
     return {
       stop: () => undefined
@@ -54,9 +54,7 @@ const testPose = poseFactory<Value, Action, Subscription, PoserAPI>({
     }
 
     const { multiply } = transitionDef;
-    return multiply
-      ? mockMultiplyAction(to, multiply)
-      : mockAction(to);
+    return multiply ? mockMultiplyAction(to, multiply) : mockAction(to);
   },
   addActionDelay: (delay, action) => action,
   defaultTransitions: new Map([['default', ({ to }) => mockActionInverse(to)]]),
@@ -64,9 +62,13 @@ const testPose = poseFactory<Value, Action, Subscription, PoserAPI>({
   readValueFromSource: () => 0,
   extendAPI: api => api,
   posePriority: ['drag', 'press', 'hover'],
-  setValue: (raw, valueToSet) => raw.i = valueToSet,
-  setValueNative: (key, valueToSet, { onNativeSet }) => onNativeSet && onNativeSet(key, valueToSet),
-  getDefaultProps: ({ props: { forGetDefault } = {} }) => ({ fromConfig: forGetDefault, defaultProp: 110 }),
+  setValue: (raw, valueToSet) => (raw.i = valueToSet),
+  setValueNative: (key, valueToSet, { onNativeSet }) =>
+    onNativeSet && onNativeSet(key, valueToSet),
+  getDefaultProps: ({ props: { forGetDefault } = {} }) => ({
+    fromConfig: forGetDefault,
+    defaultProp: 110
+  })
 });
 
 const testPoser = testPose({
@@ -104,6 +106,12 @@ const testPoser = testPose({
       x: () => ({ multiply: 5 })
     }
   },
+  functionalMapFunctionalDefTransition: {
+    x: 6,
+    transition: () => ({
+      x: () => ({ multiply: 11 })
+    })
+  },
   instantTransition: {
     x: 11,
     transition: false
@@ -114,7 +122,8 @@ const testPoser = testPose({
   },
   instantTransitionFunc: {
     x: 13,
-    transition: () => false },
+    transition: () => false
+  },
   instantTransitionMapFunc: {
     x: 14,
     transition: {
@@ -176,29 +185,28 @@ test('correctly identifies poses', () => {
   expect(testPoser.has('foo')).toBe(false);
 });
 
-test('sets poses with default transition', () => Promise.all([
-  testPoser.set('closed'),
-  testPoser.set('right')
-]).then(() => {
-  const state = testPoser.get();
-  expect(state.x).toBe(-100)
-  expect(state.y).toBe(-100)
-});
+test('sets poses with default transition', () =>
+  Promise.all([testPoser.set('closed'), testPoser.set('right')]).then(() => {
+    const state = testPoser.get();
+    expect(state.x).toBe(-100);
+    expect(state.y).toBe(-100);
+  }));
 
-test('correctly sets and updates props', () => testPoser.set('testProps')
-  .then(() => {
-    expect(testPoser.get().x).toBe(-50);
-    testPoser.setProps({ x: 51 });
-    return testPoser.set('testProps');
-  })
-  .then(() => {
-    expect(testPoser.get().x).toBe(-51);
-    return testPoser.set('testProps', { x: 52 });
-  })
-  .then(() => {
-    expect(testPoser.get().x).toBe(-52);
-  })
-);
+test('correctly sets and updates props', () =>
+  testPoser
+    .set('testProps')
+    .then(() => {
+      expect(testPoser.get().x).toBe(-50);
+      testPoser.setProps({ x: 51 });
+      return testPoser.set('testProps');
+    })
+    .then(() => {
+      expect(testPoser.get().x).toBe(-51);
+      return testPoser.set('testProps', { x: 52 });
+    })
+    .then(() => {
+      expect(testPoser.get().x).toBe(-52);
+    }));
 
 test('propagates pose changes to children', () => {
   const parent = testPose({
@@ -206,68 +214,78 @@ test('propagates pose changes to children', () => {
     a: { x: 100 }
   });
 
-  const child = parent._addChild({
-    init: { x: 10 },
-    a: { x: 50 }
-  }, testPose);
+  const child = parent._addChild(
+    {
+      init: { x: 10 },
+      a: { x: 50 }
+    },
+    testPose
+  );
 
-  return parent.set('a').then(() => {
-    expect(parent.get('x')).toBe(-100)
-    expect(child.get('x')).toBe(-50)
+  return parent
+    .set('a')
+    .then(() => {
+      expect(parent.get('x')).toBe(-100);
+      expect(child.get('x')).toBe(-50);
 
-    return parent.unset('a')
-  }).then(() => {
-    expect(parent.get('x')).toBe(-0)
-    expect(child.get('x')).toBe(-10)
-  })
-};
+      return parent.unset('a');
+    })
+    .then(() => {
+      expect(parent.get('x')).toBe(-0);
+      expect(child.get('x')).toBe(-10);
+    });
+});
 
 test('resolves custom transitions correctly', () =>
-  testPoser.set('functionalTransition')
+  testPoser
+    .set('functionalTransition')
     .then(() => {
-      expect(testPoser.get().x).toBe(10 * 10)
-      return testPoser.set('mapFunctionalTransition')
+      expect(testPoser.get().x).toBe(10 * 10);
+      return testPoser.set('mapFunctionalTransition');
     })
     .then(() => {
-      expect(testPoser.get().x).toBe(9 * 9)
-      return testPoser.set('defTransition')
+      expect(testPoser.get().x).toBe(9 * 9);
+      return testPoser.set('defTransition');
     })
     .then(() => {
-      expect(testPoser.get().x).toBe(8 * 2)
-      return testPoser.set('functionalDefTransition')
+      expect(testPoser.get().x).toBe(8 * 2);
+      return testPoser.set('functionalDefTransition');
     })
     .then(() => {
-      expect(testPoser.get().x).toBe(5 * 10)
-      return testPoser.set('mapDefTransition')
+      expect(testPoser.get().x).toBe(5 * 10);
+      return testPoser.set('mapDefTransition');
     })
     .then(() => {
-      expect(testPoser.get().x).toBe(7 * 3)
-      return testPoser.set('mapFunctionalDefTransition')
+      expect(testPoser.get().x).toBe(7 * 3);
+      return testPoser.set('mapFunctionalDefTransition');
     })
     .then(() => {
-      expect(testPoser.get().x).toBe(6 * 5)
+      expect(testPoser.get().x).toBe(6 * 5);
+      return testPoser.set('functionalMapFunctionalDefTransition');
+    })
+    .then(() => {
+      expect(testPoser.get().x).toBe(6 * 11);
       return testPoser.set('instantTransition');
     })
     .then(() => {
-      expect(testPoser.get().x).toBe(11)
+      expect(testPoser.get().x).toBe(11);
       return testPoser.set('instantTransitionMap');
     })
     .then(() => {
-      expect(testPoser.get().x).toBe(12)
+      expect(testPoser.get().x).toBe(12);
       return testPoser.set('instantTransitionFunc');
     })
     .then(() => {
-      expect(testPoser.get().x).toBe(13)
+      expect(testPoser.get().x).toBe(13);
       return testPoser.set('instantTransitionMapFunc');
     })
     .then(() => {
-      expect(testPoser.get().x).toBe(14)
-      return testPoser.set('defaultTransitionMap')
+      expect(testPoser.get().x).toBe(14);
+      return testPoser.set('defaultTransitionMap');
     })
     .then(() => {
-      expect(testPoser.get().x).toBe(45)
-    })
-);
+      expect(testPoser.get().x).toBe(45);
+    }));
 
 test('applies correct initial values', () => {
   const testDefaultsPoser = testPose({
@@ -289,34 +307,36 @@ test('applies correct initial values', () => {
 test('correctly falls back to previous pose', () => {
   const fallback = testPose({
     init: { x: 0, y: 1 },
-    hover: {x : 1 },
-    drag: {x : 2, y: 2}
+    hover: { x: 1 },
+    drag: { x: 2, y: 2 }
   });
 
   expect(fallback.get('x')).toBe(0);
-  return fallback.set('hover')
+  return fallback
+    .set('hover')
     .then(() => {
       expect(fallback.get('x')).toBe(-1);
-      return fallback.set('drag')
+      return fallback.set('drag');
     })
     .then(() => {
       expect(fallback.get('x')).toBe(-2);
-      return fallback.unset('drag')
+      return fallback.unset('drag');
     })
     .then(() => {
       expect(fallback.get('x')).toBe(-1);
-    })
+    });
 });
 
 test('setting a pose that is already set actually does reset it', () => {
   const reset = testPose({
     init: { x: 0 },
     test: { x: ({ a }) => a }
-  })
+  });
 
   expect(reset.get('x')).toBe(0);
   reset.setProps({ a: 10 });
-  return reset.set('test')
+  return reset
+    .set('test')
     .then(() => {
       expect(reset.get('x')).toBe(-10);
       reset.setProps({ a: 20 });
@@ -324,13 +344,13 @@ test('setting a pose that is already set actually does reset it', () => {
     })
     .then(() => {
       expect(reset.get('x')).toBe(-20);
-    })
-})
+    });
+});
 
 test('correctly falls back to previous pose with mismatched initialPose', () => {
   const fallback = testPose({
     init: { x: 30, y: 1 },
-    hover: {x : 1 },
+    hover: { x: 1 },
     visible: { opacity: 1 },
     hidden: { opacity: 0 },
     initialPose: 'visible'
@@ -339,16 +359,17 @@ test('correctly falls back to previous pose with mismatched initialPose', () => 
   expect(fallback.get('x')).toBe(30);
   expect(fallback.get('opacity')).toBe(1);
 
-  return fallback.set('hover')
+  return fallback
+    .set('hover')
     .then(() => {
       expect(fallback.get('x')).toBe(-1);
       expect(fallback.get('opacity')).toBe(1);
-      return fallback.unset('hover')
+      return fallback.unset('hover');
     })
     .then(() => {
       expect(fallback.get('x')).toBe(-30);
       expect(fallback.get('opacity')).toBe(1);
-    })
+    });
 });
 
 test('children fall back correctly multiple times', () => {
@@ -357,29 +378,33 @@ test('children fall back correctly multiple times', () => {
     drag: { scale: 2 },
     dragEnd: { scale: 3 }
   });
-  const child = parent._addChild({
-    init: { scale: 10 },
-    drag: { scale: 20 }
-  }, testPose);
+  const child = parent._addChild(
+    {
+      init: { scale: 10 },
+      drag: { scale: 20 }
+    },
+    testPose
+  );
 
-  return parent.set('drag')
+  return parent
+    .set('drag')
     .then(() => {
-      expect(child.get('scale')).toBe(-20)
-      parent.set('dragEnd')
-      return parent.unset('drag')
+      expect(child.get('scale')).toBe(-20);
+      parent.set('dragEnd');
+      return parent.unset('drag');
     })
     .then(() => {
-      expect(child.get('scale')).toBe(-10)
-      return parent.set('drag')
+      expect(child.get('scale')).toBe(-10);
+      return parent.set('drag');
     })
     .then(() => {
-      expect(child.get('scale')).toBe(-20)
-      parent.set('dragEnd')
-      return parent.unset('drag')
+      expect(child.get('scale')).toBe(-20);
+      parent.set('dragEnd');
+      return parent.unset('drag');
     })
     .then(() => {
-      expect(child.get('scale')).toBe(-10)
-    })
+      expect(child.get('scale')).toBe(-10);
+    });
 });
 
 test('correctly applies poses in priority order', () => {
@@ -389,26 +414,32 @@ test('correctly applies poses in priority order', () => {
     hover: { x: 20 }
   });
   expect(fallback.get('x')).toBe(0);
-  return fallback.set('hover').then(() => {
-    expect(fallback.get('x')).toBe(-20);
-    return fallback.set('drag');
-  })
-  .then(() => {
-    expect(fallback.get('x')).toBe(-10);
-    return fallback.unset('hover')
-  }).then(() => {
-    expect(fallback.get('x')).toBe(-10)
-    return fallback.set('hover')
-  }).then(() => {
-    expect(fallback.get('x')).toBe(-10)
-    return fallback.unset('drag')
-  }).then(() => {
-    expect(fallback.get('x')).toBe(-20)
-  })
+  return fallback
+    .set('hover')
+    .then(() => {
+      expect(fallback.get('x')).toBe(-20);
+      return fallback.set('drag');
+    })
+    .then(() => {
+      expect(fallback.get('x')).toBe(-10);
+      return fallback.unset('hover');
+    })
+    .then(() => {
+      expect(fallback.get('x')).toBe(-10);
+      return fallback.set('hover');
+    })
+    .then(() => {
+      expect(fallback.get('x')).toBe(-10);
+      return fallback.unset('drag');
+    })
+    .then(() => {
+      expect(fallback.get('x')).toBe(-20);
+    });
 });
 
 test('correctly applies values at start and end', () => {
-  return testPoser.set('withStart')
+  return testPoser
+    .set('withStart')
     .then(() => {
       expect(testPoser.get('x')).toBe(1000);
       expect(testPoser.get('y')).toBe(-200);
@@ -426,7 +457,7 @@ test('correctly applies values at start and end', () => {
     })
     .then(() => {
       expect(testPoser.get('x')).toBe(6000);
-    })
+    });
 });
 
 test('correctly applies start/end values on initialisation', () => {
@@ -448,7 +479,7 @@ test('correctly applies start/end values on initialisation', () => {
         bar: 3
       }
     },
-    props: { onNativeSet: (key, v) => native[key] = v }
+    props: { onNativeSet: (key, v) => (native[key] = v) }
   });
 
   expect(native.foo).toBe(3);
@@ -459,43 +490,43 @@ test('correctly applies start/end values on initialisation', () => {
 test('getDefaultProps adds default props', () => {
   const poser = testPose({
     init: {
-      x: 0,
+      x: 0
     },
     opened: {
-      x: ({ defaultProp }) => defaultProp,
-    },
+      x: ({ defaultProp }) => defaultProp
+    }
   });
 
   return poser.set('opened').then(() => {
     expect(poser.get('x')).toBe(-110);
-  })
+  });
 });
 
 test('getDefaultProps is able to read from config', () => {
   const poser = testPose({
     init: {
-      x: 0,
+      x: 0
     },
     opened: {
-      x: ({ fromConfig }) => fromConfig,
+      x: ({ fromConfig }) => fromConfig
     },
     props: {
-      forGetDefault: 10,
+      forGetDefault: 10
     }
   });
 
   return poser.set('opened').then(() => {
     expect(poser.get('x')).toBe(-10);
-  })
+  });
 });
 
 test("getDefaultProps doesn't override own props", () => {
   const poser = testPose({
     init: {
-      x: 0,
+      x: 0
     },
     opened: {
-      x: ({ fromConfig }) => fromConfig,
+      x: ({ fromConfig }) => fromConfig
     },
     props: {
       forGetDefault: 10,
@@ -505,5 +536,5 @@ test("getDefaultProps doesn't override own props", () => {
 
   return poser.set('opened').then(() => {
     expect(poser.get('x')).toBe(-200);
-  })
+  });
 });

--- a/packages/pose-core/src/factories/setter.ts
+++ b/packages/pose-core/src/factories/setter.ts
@@ -97,6 +97,19 @@ const resolveTransition = <V, A>(
   if (typeof transition === 'function') {
     resolvedTransition = transition(props);
 
+    /**
+     * transition: () => { d: () => tweenFn }
+     */
+    if (typeof resolvedTransition === 'object') {
+      resolvedTransition = resolveTransition(
+        resolvedTransition as TransitionMap<A>,
+        key,
+        value,
+        props,
+        convertTransitionDefinition,
+        getInstantTransition);
+    }
+
     // Or if it's a keyed object
   } else if (transition[key] || transition.default) {
     const keyTransition = transition[key] || transition.default;

--- a/packages/pose-core/src/factories/setter.ts
+++ b/packages/pose-core/src/factories/setter.ts
@@ -12,8 +12,8 @@ import {
   TransformPose,
   AddTransitionDelay,
   ConvertTransitionDefinition,
-  TransitionDefinition,
   TransitionFactory,
+  TransitionMapFactory,
   TransitionMap,
   SetValue,
   SetValueNative,
@@ -24,9 +24,9 @@ import { invariant } from 'hey-listen';
 
 type AnimationsPromiseList = Array<Promise<any>>;
 
-type SetterFactoryProps<V, A, C, P> = {
+type SetterFactoryProps<V, A, C, P, TD> = {
   state: PoserState<V, A, C, P>;
-  poses: PoseMap<A>;
+  poses: PoseMap<A, TD>;
   getInstantTransition: GetInstantTransition<V, A>;
   startAction: StartAction<V, A, C>;
   stopAction: StopAction<C>;
@@ -35,16 +35,16 @@ type SetterFactoryProps<V, A, C, P> = {
   addActionDelay: AddTransitionDelay<A>;
   getTransitionProps: GetTransitionProps<V>;
   resolveTarget: ResolveTarget<V>;
-  convertTransitionDefinition: ConvertTransitionDefinition<V, A>;
-  transformPose?: TransformPose<V, A, C, P>;
+  convertTransitionDefinition: ConvertTransitionDefinition<V, A, TD>;
+  transformPose?: TransformPose<V, A, C, P, TD>;
   posePriority?: string[];
 };
 
 export const resolveProp = (target: any, props: Props) =>
   typeof target === 'function' ? target(props) : target;
 
-const poseDefault = <A>(
-  pose: Pose<A>,
+const poseDefault = <A, TD>(
+  pose: Pose<A, TD>,
   prop: string,
   defaultValue: any,
   resolveProps: Props
@@ -53,16 +53,21 @@ const poseDefault = <A>(
     ? resolveProp(pose[prop], resolveProps)
     : defaultValue;
 
-const startChildAnimations = <V, A, C, P>(
+const startChildAnimations = <V, A, C, P, TD>(
   children: ChildPosers<V, A, C, P>,
   next: string,
-  pose: Pose<A>,
+  pose: Pose<A, TD>,
   props: Props
 ) => {
   const animations: Array<Promise<any>> = [];
-  const delay = poseDefault<A>(pose, 'delayChildren', 0, props);
-  const stagger = poseDefault<A>(pose, 'staggerChildren', 0, props);
-  const staggerDirection = poseDefault<A>(pose, 'staggerDirection', 1, props);
+  const delay = poseDefault<A, TD>(pose, 'delayChildren', 0, props);
+  const stagger = poseDefault<A, TD>(pose, 'staggerChildren', 0, props);
+  const staggerDirection = poseDefault<A, TD>(
+    pose,
+    'staggerDirection',
+    1,
+    props
+  );
 
   const maxStaggerDuration = (children.size - 1) * stagger;
   const generateStaggerDuration =
@@ -81,27 +86,27 @@ const startChildAnimations = <V, A, C, P>(
   return animations;
 };
 
-const resolveTransition = <V, A>(
-  transition: TransitionMap<A> | TransitionFactory<A>,
+const resolveTransition = <V, A, TD>(
+  transition: TransitionMap<A, TD> | TransitionMapFactory<A, TD>,
   key: string,
   value: V,
   props: Props,
-  convertTransitionDefinition: ConvertTransitionDefinition<V, A>,
+  convertTransitionDefinition: ConvertTransitionDefinition<V, A, TD>,
   getInstantTransition: GetInstantTransition<V, A>
 ): A => {
-  let resolvedTransition: A | false | TransitionDefinition;
+  let resolvedTransition: ReturnType<TransitionFactory<A, TD>>;
 
   /**
    * transition: () => {}
    */
   if (typeof transition === 'function') {
-    resolvedTransition = transition(props);
+    const resolvedTransitionMap = transition(props);
 
     /**
      * transition: () => { d: () => tweenFn }
      */
     resolvedTransition = resolveTransition(
-      resolvedTransition as TransitionMap<A>,
+      resolvedTransitionMap,
       key,
       value,
       props,
@@ -118,7 +123,7 @@ const resolveTransition = <V, A>(
      * }
      */
     if (typeof keyTransition === 'function') {
-      resolvedTransition = (keyTransition as TransitionFactory<A>)(props);
+      resolvedTransition = (keyTransition as TransitionFactory<A, TD>)(props);
 
       /**
        * transition: {
@@ -133,7 +138,7 @@ const resolveTransition = <V, A>(
      * transition: { type: 'tween' } || false
      */
   } else {
-    resolvedTransition = transition;
+    resolvedTransition = (transition as any) as typeof resolvedTransition;
   }
 
   return resolvedTransition === false
@@ -178,8 +183,8 @@ const applyValues = <V>(
   });
 };
 
-const createPoseSetter = <V, A, C, P>(
-  setterProps: SetterFactoryProps<V, A, C, P>
+const createPoseSetter = <V, A, C, P, TD>(
+  setterProps: SetterFactoryProps<V, A, C, P, TD>
 ) => {
   const {
     state,
@@ -284,7 +289,7 @@ const createPoseSetter = <V, A, C, P>(
                 ...getTransitionProps(value, target, transitionProps)
               };
 
-              let transition = resolveTransition<V, A>(
+              let transition = resolveTransition<V, A, TD>(
                 getTransition,
                 key,
                 value,

--- a/packages/pose-core/src/factories/setter.ts
+++ b/packages/pose-core/src/factories/setter.ts
@@ -100,16 +100,14 @@ const resolveTransition = <V, A>(
     /**
      * transition: () => { d: () => tweenFn }
      */
-    if (typeof resolvedTransition === 'object') {
-      resolvedTransition = resolveTransition(
-        resolvedTransition as TransitionMap<A>,
-        key,
-        value,
-        props,
-        convertTransitionDefinition,
-        getInstantTransition);
-    }
-
+    resolvedTransition = resolveTransition(
+      resolvedTransition as TransitionMap<A>,
+      key,
+      value,
+      props,
+      convertTransitionDefinition,
+      getInstantTransition
+    );
     // Or if it's a keyed object
   } else if (transition[key] || transition.default) {
     const keyTransition = transition[key] || transition.default;
@@ -296,7 +294,8 @@ const createPoseSetter = <V, A, C, P>(
               );
 
               // Add delay if defined on pose
-              const poseDelay = delay || resolveProp(nextPose.delay, transitionProps);
+              const poseDelay =
+                delay || resolveProp(nextPose.delay, transitionProps);
               if (poseDelay) {
                 transition = addActionDelay(poseDelay, transition);
               }

--- a/packages/pose-core/src/factories/transitions.ts
+++ b/packages/pose-core/src/factories/transitions.ts
@@ -1,16 +1,16 @@
-import { PoseMap, Pose, TransitionFactory, TransitionMap } from '../types';
+import { PoseMap, Pose, TransitionMapFactory, TransitionMap } from '../types';
 import { invariant } from 'hey-listen';
 
-type DefaultTransitions<A> = Map<
+type DefaultTransitions<A, TD> = Map<
   string,
-  TransitionFactory<A> | TransitionMap<A>
+  TransitionMap<A, TD> | TransitionMapFactory<A, TD>
 >;
 
-const applyDefaultTransition = <A>(
-  pose: Pose<A>,
+const applyDefaultTransition = <A, TD>(
+  pose: Pose<A, TD>,
   key: string,
-  defaultTransitions: DefaultTransitions<A>
-): Pose<A> => {
+  defaultTransitions: DefaultTransitions<A, TD>
+): Pose<A, TD> => {
   return {
     ...pose,
     transition: defaultTransitions.has(key)
@@ -19,10 +19,10 @@ const applyDefaultTransition = <A>(
   };
 };
 
-const generateTransitions = <A>(
-  poses: PoseMap<A>,
-  defaultTransitions: DefaultTransitions<A>
-): PoseMap<A> => {
+const generateTransitions = <A, TD>(
+  poses: PoseMap<A, TD>,
+  defaultTransitions: DefaultTransitions<A, TD>
+): PoseMap<A, TD> => {
   Object.keys(poses).forEach(key => {
     const pose = poses[key];
 
@@ -34,7 +34,7 @@ const generateTransitions = <A>(
     poses[key] =
       pose.transition !== undefined
         ? pose
-        : applyDefaultTransition<A>(pose, key, defaultTransitions);
+        : applyDefaultTransition<A, TD>(pose, key, defaultTransitions);
   });
 
   return poses;

--- a/packages/pose-core/src/inc/selectors.ts
+++ b/packages/pose-core/src/inc/selectors.ts
@@ -6,7 +6,7 @@ import {
   SelectValueToRead
 } from '../types';
 
-export const getPoseValues = <A>({
+export const getPoseValues = <A, TD>({
   transition,
   delay,
   delayChildren,
@@ -18,9 +18,9 @@ export const getPoseValues = <A>({
   applyAtStart,
   applyAtEnd,
   ...props
-}: Pose<A>): Pose<A> => props;
+}: Pose<A, TD>): Pose<A, TD> => props;
 
-export const selectPoses = <V, A>({
+export const selectPoses = <V, A, TD>({
   label,
   props,
   values,
@@ -30,7 +30,7 @@ export const selectPoses = <V, A>({
   passive,
   initialPose,
   ...poses
-}: PoserConfig<V>): PoseMap<A> => poses;
+}: PoserConfig<V>): PoseMap<A, TD> => poses;
 
 export const selectAllValues = <V>(
   values: ValueMap<V>,

--- a/packages/pose-core/src/index.ts
+++ b/packages/pose-core/src/index.ts
@@ -20,7 +20,7 @@ import generateDefaultTransitions from './factories/transitions';
 import { selectPoses, selectAllValues } from './inc/selectors';
 import { sortByReversePriority } from './inc/utils';
 
-const poseFactory = <V, A, C, P>({
+const poseFactory = <V, A, C, P, TD>({
   getDefaultProps,
   defaultTransitions,
   bindOnChange,
@@ -41,7 +41,7 @@ const poseFactory = <V, A, C, P>({
   transformPose,
   posePriority,
   extendAPI
-}: PoseFactoryConfig<V, A, C, P>) => (
+}: PoseFactoryConfig<V, A, C, P, TD>) => (
   config: PoserConfig<V>
 ): Poser<V, A, C, P> => {
   // If set, add parent values to ancestor chain
@@ -52,7 +52,7 @@ const poseFactory = <V, A, C, P>({
   const activePoses: ActivePoses = new Map();
   const children: ChildPosers<V, A, C, P> = new Set();
 
-  const poses = generateDefaultTransitions<A>(
+  const poses = generateDefaultTransitions<A, TD>(
     selectPoses(config),
     defaultTransitions
   );
@@ -68,7 +68,7 @@ const poseFactory = <V, A, C, P>({
     initialPose = DEFAULT_INITIAL_POSE
   } = config;
 
-  const values = createValueMap<V, A>({
+  const values = createValueMap<V, A, TD>({
     poses,
     passive,
     ancestorValues,

--- a/packages/pose-core/src/types.ts
+++ b/packages/pose-core/src/types.ts
@@ -3,25 +3,23 @@ export type Props = { [key: string]: any };
 export type NumberPropFactory = (props: Props) => number;
 export type BooleanPropFactory = (props: Props) => boolean;
 export type StaggerDirectionPropFactory = (props: Props) => 1 | -1;
-export type TransitionFactory<A> = (
-  props: Props
-) => TransitionDefinition | A | false;
+export type TransitionFactory<A, TD> = (props: Props) => TD | A | false;
 
 export type ApplyResolve = (props: Props) => string | number;
 export type ApplyMap = {
   [key: string]: ApplyResolve | string | number;
 };
 
-export type TransitionDefinition = {
-  [key: string]: any;
+export type TransitionMap<A, TD> = {
+  [key: string]: TD | A | false | TransitionFactory<A, TD>;
 };
 
-export type TransitionMap<A> = {
-  [key: string]: TransitionDefinition | TransitionFactory<A>;
-};
+export type TransitionMapFactory<A, TD> = (
+  props: Props
+) => TransitionMap<A, TD>;
 
-export type Pose<A> = {
-  transition?: TransitionMap<A> | TransitionFactory<A>;
+export type Pose<A, TD> = {
+  transition?: TransitionMap<A, TD> | TransitionMapFactory<A, TD>;
   delay?: number | NumberPropFactory;
   delayChildren?: number | NumberPropFactory;
   staggerChildren?: number | NumberPropFactory;
@@ -59,8 +57,8 @@ export type ActivePoses = Map<string, string[]>;
 
 export type ChildPosers<V, A, C, P> = Set<Poser<V, A, C, P>>;
 
-export type PoseMap<A> = {
-  [key: string]: Pose<A>;
+export type PoseMap<A, TD> = {
+  [key: string]: Pose<A, TD>;
 };
 
 export type PoserFactory<V, A, C, P> = (
@@ -143,26 +141,29 @@ export type GetTransitionProps<V> = (
 
 export type SelectValueToRead<V> = (value: V) => any;
 
-export type TransformPose<V, A, C, P> = (
-  pose: Pose<A>,
+export type TransformPose<V, A, C, P, TD> = (
+  pose: Pose<A, TD>,
   key: string,
   state: PoserState<V, A, C, P>
-) => Pose<A>;
+) => Pose<A, TD>;
 
 export type ReadValueFromSource = (key: string, props: Props) => any;
 
 export type SetValue<V> = (v: V, value: any) => void;
 export type SetValueNative = (key: string, value: any, props: Props) => void;
 
-export type ConvertTransitionDefinition<V, A> = (
+export type ConvertTransitionDefinition<V, A, TD> = (
   value: V,
-  transitionDef: TransitionDefinition,
+  transitionDef: TD | A,
   props: Props
 ) => A;
 
-export type PoseFactoryConfig<V, A, C, P> = {
+export type PoseFactoryConfig<V, A, C, P, TD> = {
   getDefaultProps?: (config: PoserConfig<V>) => Props;
-  defaultTransitions?: Map<string, TransitionMap<A> | TransitionFactory<A>>;
+  defaultTransitions?: Map<
+    string,
+    TransitionMap<A, TD> | TransitionMapFactory<A, TD>
+  >;
   bindOnChange: (
     values: ValueMap<V>,
     onChange: OnChangeCallbacks
@@ -175,13 +176,13 @@ export type PoseFactoryConfig<V, A, C, P> = {
   convertValue: ConvertValue<V>;
   resolveTarget: ResolveTarget<V>;
   getTransitionProps: GetTransitionProps<V>;
-  convertTransitionDefinition: ConvertTransitionDefinition<V, A>;
+  convertTransitionDefinition: ConvertTransitionDefinition<V, A, TD>;
   startAction: StartAction<V, A, C>;
   stopAction: StopAction<C>;
   getInstantTransition: GetInstantTransition<V, A>;
   addActionDelay: AddTransitionDelay<A>;
   selectValueToRead: SelectValueToRead<V>;
   extendAPI: ExtendAPI<V, A, C, P>;
-  transformPose?: TransformPose<V, A, C, P>;
+  transformPose?: TransformPose<V, A, C, P, TD>;
   posePriority?: string[];
 };

--- a/packages/pose-core/src/types.ts
+++ b/packages/pose-core/src/types.ts
@@ -160,10 +160,7 @@ export type ConvertTransitionDefinition<V, A, TD> = (
 
 export type PoseFactoryConfig<V, A, C, P, TD> = {
   getDefaultProps?: (config: PoserConfig<V>) => Props;
-  defaultTransitions?: Map<
-    string,
-    TransitionMap<A, TD> | TransitionMapFactory<A, TD>
-  >;
+  defaultTransitions?: Map<string, TransitionMap<A, TD>>;
   bindOnChange: (
     values: ValueMap<V>,
     onChange: OnChangeCallbacks

--- a/yarn.lock
+++ b/yarn.lock
@@ -3190,13 +3190,21 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-jest@^22.4.1, babel-jest@^22.4.3, babel-jest@^23.6.0:
+babel-jest@^22.4.1, babel-jest@^22.4.4:
   version "22.4.4"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-22.4.4.tgz#977259240420e227444ebe49e226a61e49ea659d"
   integrity sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==
   dependencies:
     babel-plugin-istanbul "^4.1.5"
     babel-preset-jest "^22.4.4"
+
+babel-jest@^23.6.0:
+  version "23.6.0"
+  resolved "https://registry.npmjs.org/babel-jest/-/babel-jest-23.6.0.tgz#a644232366557a2240a0c083da6b25786185a2f1"
+  integrity sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==
+  dependencies:
+    babel-plugin-istanbul "^4.1.6"
+    babel-preset-jest "^23.2.0"
 
 babel-loader@7.1.2:
   version "7.1.2"
@@ -3290,6 +3298,11 @@ babel-plugin-jest-hoist@^22.4.4:
   version "22.4.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz#b9851906eab34c7bf6f8c895a2b08bea1a844c0b"
   integrity sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ==
+
+babel-plugin-jest-hoist@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
+  integrity sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=
 
 babel-plugin-macros@^2.2.0:
   version "2.4.2"
@@ -4134,6 +4147,14 @@ babel-preset-jest@^22.4.3, babel-preset-jest@^22.4.4:
   integrity sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==
   dependencies:
     babel-plugin-jest-hoist "^22.4.4"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+
+babel-preset-jest@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"
+  integrity sha1-jsegOhOPABoaj7HoETZSvxpV2kY=
+  dependencies:
+    babel-plugin-jest-hoist "^23.2.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-preset-minify@^0.3.0:
@@ -10139,7 +10160,7 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
-istanbul-api@^1.3.1:
+istanbul-api@^1.1.14, istanbul-api@^1.3.1:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.3.7.tgz#a86c770d2b03e11e3f778cd7aedd82d2722092aa"
   integrity sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==
@@ -10156,7 +10177,7 @@ istanbul-api@^1.3.1:
     mkdirp "^0.5.1"
     once "^1.4.0"
 
-istanbul-lib-coverage@^1.2.0, istanbul-lib-coverage@^1.2.1:
+istanbul-lib-coverage@^1.1.1, istanbul-lib-coverage@^1.2.0, istanbul-lib-coverage@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz#ccf7edcd0a0bb9b8f729feeb0930470f9af664f0"
   integrity sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==
@@ -10168,7 +10189,7 @@ istanbul-lib-hook@^1.2.2:
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.10.1, istanbul-lib-instrument@^1.10.2:
+istanbul-lib-instrument@^1.10.1, istanbul-lib-instrument@^1.10.2, istanbul-lib-instrument@^1.8.0:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz#1f55ed10ac3c47f2bdddd5307935126754d0a9ca"
   integrity sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==
@@ -10191,7 +10212,7 @@ istanbul-lib-report@^1.1.5:
     path-parse "^1.0.5"
     supports-color "^3.1.2"
 
-istanbul-lib-source-maps@^1.2.4, istanbul-lib-source-maps@^1.2.6:
+istanbul-lib-source-maps@^1.2.1, istanbul-lib-source-maps@^1.2.4, istanbul-lib-source-maps@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz#37b9ff661580f8fca11232752ee42e08c6675d8f"
   integrity sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==
@@ -10227,12 +10248,59 @@ javascript-stringify@^1.6.0:
   resolved "https://registry.yarnpkg.com/javascript-stringify/-/javascript-stringify-1.6.0.tgz#142d111f3a6e3dae8f4a9afd77d45855b5a9cce3"
   integrity sha1-FC0RHzpuPa6PSpr9d9RYVbWpzOM=
 
+jest-changed-files@^22.2.0:
+  version "22.4.3"
+  resolved "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz#8882181e022c38bd46a2e4d18d44d19d90a90fb2"
+  integrity sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==
+  dependencies:
+    throat "^4.0.0"
+
 jest-changed-files@^23.4.2:
   version "23.4.2"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.4.2.tgz#1eed688370cd5eebafe4ae93d34bb3b64968fe83"
   integrity sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==
   dependencies:
     throat "^4.0.0"
+
+jest-cli@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.4.tgz#68cd2a2aae983adb1e6638248ca21082fd6d9e90"
+  integrity sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    exit "^0.1.2"
+    glob "^7.1.2"
+    graceful-fs "^4.1.11"
+    import-local "^1.0.0"
+    is-ci "^1.0.10"
+    istanbul-api "^1.1.14"
+    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-instrument "^1.8.0"
+    istanbul-lib-source-maps "^1.2.1"
+    jest-changed-files "^22.2.0"
+    jest-config "^22.4.4"
+    jest-environment-jsdom "^22.4.1"
+    jest-get-type "^22.1.0"
+    jest-haste-map "^22.4.2"
+    jest-message-util "^22.4.0"
+    jest-regex-util "^22.1.0"
+    jest-resolve-dependencies "^22.1.0"
+    jest-runner "^22.4.4"
+    jest-runtime "^22.4.4"
+    jest-snapshot "^22.4.0"
+    jest-util "^22.4.1"
+    jest-validate "^22.4.4"
+    jest-worker "^22.2.2"
+    micromatch "^2.3.11"
+    node-notifier "^5.2.1"
+    realpath-native "^1.0.0"
+    rimraf "^2.5.4"
+    slash "^1.0.0"
+    string-length "^2.0.0"
+    strip-ansi "^4.0.0"
+    which "^1.2.12"
+    yargs "^10.0.3"
 
 jest-cli@^23.1.0, jest-cli@^23.6.0:
   version "23.6.0"
@@ -10367,7 +10435,7 @@ jest-docblock@22.4.0:
   dependencies:
     detect-newline "^2.1.0"
 
-jest-docblock@^22.4.0:
+jest-docblock@^22.4.0, jest-docblock@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-22.4.3.tgz#50886f132b42b280c903c592373bb6e93bb68b19"
   integrity sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==
@@ -10473,6 +10541,19 @@ jest-haste-map@22.4.2:
     micromatch "^2.3.11"
     sane "^2.0.0"
 
+jest-haste-map@^22.4.2:
+  version "22.4.3"
+  resolved "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz#25842fa2ba350200767ac27f658d58b9d5c2e20b"
+  integrity sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==
+  dependencies:
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-docblock "^22.4.3"
+    jest-serializer "^22.4.3"
+    jest-worker "^22.4.3"
+    micromatch "^2.3.11"
+    sane "^2.0.0"
+
 jest-haste-map@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.6.0.tgz#2e3eb997814ca696d62afdb3f2529f5bbc935e16"
@@ -10535,6 +10616,13 @@ jest-jasmine2@^23.6.0:
     jest-snapshot "^23.6.0"
     jest-util "^23.4.0"
     pretty-format "^23.6.0"
+
+jest-leak-detector@^22.4.0:
+  version "22.4.3"
+  resolved "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz#2b7b263103afae8c52b6b91241a2de40117e5b35"
+  integrity sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==
+  dependencies:
+    pretty-format "^22.4.3"
 
 jest-leak-detector@^23.6.0:
   version "23.6.0"
@@ -10631,6 +10719,13 @@ jest-regex-util@^23.3.0:
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.3.0.tgz#5f86729547c2785c4002ceaa8f849fe8ca471bc5"
   integrity sha1-X4ZylUfCeFxAAs6qj4Sf6MpHG8U=
 
+jest-resolve-dependencies@^22.1.0:
+  version "22.4.3"
+  resolved "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz#e2256a5a846732dc3969cb72f3c9ad7725a8195e"
+  integrity sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==
+  dependencies:
+    jest-regex-util "^22.4.3"
+
 jest-resolve-dependencies@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz#b4526af24c8540d9a3fab102c15081cf509b723d"
@@ -10665,6 +10760,23 @@ jest-resolve@^23.6.0:
     chalk "^2.0.1"
     realpath-native "^1.0.0"
 
+jest-runner@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.4.tgz#dfca7b7553e0fa617e7b1291aeb7ce83e540a907"
+  integrity sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==
+  dependencies:
+    exit "^0.1.2"
+    jest-config "^22.4.4"
+    jest-docblock "^22.4.0"
+    jest-haste-map "^22.4.2"
+    jest-jasmine2 "^22.4.4"
+    jest-leak-detector "^22.4.0"
+    jest-message-util "^22.4.0"
+    jest-runtime "^22.4.4"
+    jest-util "^22.4.1"
+    jest-worker "^22.2.2"
+    throat "^4.0.0"
+
 jest-runner@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.6.0.tgz#3894bd219ffc3f3cb94dc48a4170a2e6f23a5a38"
@@ -10683,6 +10795,32 @@ jest-runner@^23.6.0:
     jest-worker "^23.2.0"
     source-map-support "^0.5.6"
     throat "^4.0.0"
+
+jest-runtime@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.4.tgz#9ba7792fc75582a5be0f79af6f8fe8adea314048"
+  integrity sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==
+  dependencies:
+    babel-core "^6.0.0"
+    babel-jest "^22.4.4"
+    babel-plugin-istanbul "^4.1.5"
+    chalk "^2.0.1"
+    convert-source-map "^1.4.0"
+    exit "^0.1.2"
+    graceful-fs "^4.1.11"
+    jest-config "^22.4.4"
+    jest-haste-map "^22.4.2"
+    jest-regex-util "^22.1.0"
+    jest-resolve "^22.4.2"
+    jest-util "^22.4.1"
+    jest-validate "^22.4.4"
+    json-stable-stringify "^1.0.1"
+    micromatch "^2.3.11"
+    realpath-native "^1.0.0"
+    slash "^1.0.0"
+    strip-bom "3.0.0"
+    write-file-atomic "^2.1.0"
+    yargs "^10.0.3"
 
 jest-runtime@^23.6.0:
   version "23.6.0"
@@ -10711,7 +10849,7 @@ jest-runtime@^23.6.0:
     write-file-atomic "^2.1.0"
     yargs "^11.0.0"
 
-jest-serializer@^22.4.0:
+jest-serializer@^22.4.0, jest-serializer@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-22.4.3.tgz#a679b81a7f111e4766235f4f0c46d230ee0f7436"
   integrity sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw==
@@ -10848,7 +10986,7 @@ jest-worker@22.2.2:
   dependencies:
     merge-stream "^1.0.1"
 
-jest-worker@^22.2.2:
+jest-worker@^22.2.2, jest-worker@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-22.4.3.tgz#5c421417cba1c0abf64bf56bd5fb7968d79dd40b"
   integrity sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==
@@ -10862,7 +11000,15 @@ jest-worker@^23.2.0:
   dependencies:
     merge-stream "^1.0.1"
 
-jest@^22.4.2, jest@^22.4.3, jest@^23.1.0:
+jest@^22.4.2, jest@^22.4.3:
+  version "22.4.4"
+  resolved "https://registry.npmjs.org/jest/-/jest-22.4.4.tgz#ffb36c9654b339a13e10b3d4b338eb3e9d49f6eb"
+  integrity sha512-eBhhW8OS/UuX3HxgzNBSVEVhSuRDh39Z1kdYkQVWna+scpgsrD7vSeBI7tmEvsguPDMnfJodW28YBnhv/BzSew==
+  dependencies:
+    import-local "^1.0.0"
+    jest-cli "^22.4.4"
+
+jest@^23.1.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-23.6.0.tgz#ad5835e923ebf6e19e7a1d7529a432edfee7813d"
   integrity sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==
@@ -17904,6 +18050,11 @@ tryer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+
+ts-essentials@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/ts-essentials/-/ts-essentials-1.0.3.tgz#561878f6ec0f5452633e088703b898155aebd07a"
+  integrity sha512-5znXENyA4zAActRA8Wh6/NPqc3jJEGez8wT+4YrjyITdG7rxYek4o5iO9BiA75lRNl5tL8jHx3uqhw6sgol2cg==
 
 ts-jest@^21.2.4:
   version "21.2.4"


### PR DESCRIPTION
This should allow for stricter type checking of used `transition`s. It's built on top of the @amcdnl fix for #646