### PR TITLE
Fix typo in react hover example.

### DIFF
--- a/packages/popmotion-pose/docs/examples/react/event-hover.md
+++ b/packages/popmotion-pose/docs/examples/react/event-hover.md
@@ -6,7 +6,7 @@ category: react
 
 # Events: Hover
 
-To animate an element on press, set `hoverable: true` and a `pose` prop.
+To animate an element on hover, set `hoverable: true` and a `pose` prop.
 
 ```javascript
 const config = {


### PR DESCRIPTION
The react hover example seems to have been based on the press example, this PR replaces a "press" reference with "hover".