### PR TITLE
Unset event endPose when setting startPose

### DIFF
--- a/packages/popmotion-pose/src/dom/events.ts
+++ b/packages/popmotion-pose/src/dom/events.ts
@@ -56,6 +56,7 @@ const makeUIEventApplicator = ({
 
   const eventStartListener = listen(element, startEvents).start(
     (startEvent: MouseEvent | TouchEvent) => {
+      poser.unset(endPose);
       poser.set(startPose);
 
       if (startCallback && config[startCallback])


### PR DESCRIPTION
fixes #761

However it's hard to tell if it doesn't break anything - it seems reasonable though to do this anyway. Otherwise endPose stay in the activePoses and when we unset startPose on 2nd interaction it gets set (incorrectly) in unset here:
https://github.com/Popmotion/popmotion/blob/6a4e0f2740b68a576a02a1c7f04f26c99542217d/packages/pose-core/src/index.ts#L142

Which caused endPose to be set twice when ending second interaction and messes up velocity and such