### PR TITLE
Fix inertia action being completed in the middle of its internal sequ…

### DIFF
--- a/packages/popmotion/src/animations/inertia/index.ts
+++ b/packages/popmotion/src/animations/inertia/index.ts
@@ -34,14 +34,17 @@ const inertia = ({
       );
     };
 
-    const startAnimation = (animation: Action, onComplete?: Function) => {
+    const startAnimation = (animation: Action, next?: Function) => {
       activeAnimation && activeAnimation.stop();
 
       activeAnimation = animation.start({
         update: (v: number) => current.update(v),
         complete: () => {
+          if (next) {
+            next();
+            return;
+          }
           complete();
-          onComplete && onComplete();
         }
       });
     };
@@ -99,6 +102,8 @@ const inertia = ({
 
         if (isOutOfBounds(v)) {
           startSpring({ from: v, velocity: current.getVelocity() });
+        } else {
+          complete();
         }
       });
     } else {


### PR DESCRIPTION
…ence

While reading the source I've noticed that inertia is being completed too soon - it sometimes runs a decay first and later chains a spring to it, but the action was completed unconditionally in the animation's complete callback so after mentioned decay and not after the whole sequence. This could have led to the latter spring interfering with any other actions chained to inertia.

I've not tested this thoroughly though, so please read the code carefully before merging.