### PR TITLE
fix: the poseComplete event can not work #498

### DIFF
--- a/packages/vue-pose/src/components/pose-transition.ts
+++ b/packages/vue-pose/src/components/pose-transition.ts
@@ -11,7 +11,8 @@ type TransitionHandler = (
 const setPoserTo = (
   fromPose: string,
   toPose: string,
-  defaultConfig: Object
+  defaultConfig: Object,
+  that: Vue
 ): TransitionHandler => (el, done) => {
   if (!PoserMap.has(el)) {
     PoserMap.set(
@@ -22,7 +23,10 @@ const setPoserTo = (
 
   PoserMap.get(el)
     .set(toPose)
-    .then(done);
+    .then(function(){
+      that.$emit('poseComplete', toPose);
+      done();
+    });
 };
 
 const initPoser = (
@@ -65,12 +69,12 @@ const PoseTransition: PosedComponent = Vue.extend({
     this.on = {
       beforeEnter: initPoser(setPrePose, exitPose),
       beforeLeave: initPoser(setPrePose, enterPose),
-      enter: setPoserTo(exitPose, enterPose, defaultConfig),
-      leave: setPoserTo(enterPose, exitPose, defaultConfig)
+      enter: setPoserTo(exitPose, enterPose, defaultConfig, this),
+      leave: setPoserTo(enterPose, exitPose, defaultConfig, this)
     };
 
     if (appear !== undefined) {
-      this.on.appear = setPoserTo(exitPose, enterPose, defaultConfig);
+      this.on.appear = setPoserTo(exitPose, enterPose, defaultConfig, this);
       this.on.beforeAppear = initPoser(setPrePose, exitPose);
     }
   },

--- a/packages/vue-pose/src/components/posed.ts
+++ b/packages/vue-pose/src/components/posed.ts
@@ -42,10 +42,10 @@ const watch = {
     this.poser.setProps(newAttrs);
   },
   pose(newPose: string, oldPose: string) {
-    if (newPose !== oldPose) this.poser.set(newPose);
+    if (newPose !== oldPose) this.setPose(newPose);
   },
   poseKey(newPoseKey: string | number, oldPoseKey: string | number) {
-    if (newPoseKey !== oldPoseKey) this.poser.set(this.pose);
+    if (newPoseKey !== oldPoseKey) this.setPose(this.pose);
   }
 };
 
@@ -78,8 +78,7 @@ const methods = {
     if (firstPose) this.setPose(firstPose);
   },
   setPose(pose: string) {
-    const { onPoseComplete } = this.$props;
-    this.poser.set(pose).then(() => onPoseComplete && onPoseComplete(pose));
+    this.poser.set(pose).then(() => this.$emit('poseComplete', pose));
   },
   flushChildren() {
     if (!this.children) return;


### PR DESCRIPTION
Compliance with the vue specification

* Change onPoseComplete prop to the @poseComplete vue event.

**Note:**

* put the poseComplete event on pose-transition now.

More detail to see #498 .