### PR TITLE
Update README.md

### DIFF
--- a/packages/framesync/README.md
+++ b/packages/framesync/README.md
@@ -35,7 +35,7 @@ sync.update(() => {});
 Each function is provided data about the current frame:
 
 ```javascript
-sync.update({ delta, timestamp }) => {});
+sync.update(({ delta, timestamp }) => {});
 ```
 
 - `delta`: Time since last frame (in milliseconds)


### PR DESCRIPTION
Line 38 had a missing opening parenthesis and would've caused a syntax error. It's a minor change and I'm not sure what guidelines I need to follow to change the README.md. 