### PR TITLE
Remove hard-coded perspective value when creating a transform properties

### DIFF
--- a/packages/react-native-pose/src/inc/utils.ts
+++ b/packages/react-native-pose/src/inc/utils.ts
@@ -74,7 +74,7 @@ export const getStylesFromPoser = (poser: AnimatedPoser) => {
         }
         return acc;
       },
-      [{ perspective: 1000 }] as TransformList
+      [] as TransformList
     );
   }
 


### PR DESCRIPTION
This was resulting in low quality rasterisation on iOS, which got increasingly worse the more deeply nested animations were.

Fixes: https://github.com/Popmotion/popmotion/issues/590, https://github.com/Popmotion/popmotion/issues/660 (the second half of this issue was this React Native issue), https://github.com/Popmotion/popmotion/issues/404

It's worth noting in this PR that @InventingWithMonster believes this may have originally been added to solve an Android issue, but isn't sure what that issue was, and I can't work it out either.