### PR TITLE
Added pause/resume to chain and delay

### DIFF
--- a/packages/popmotion/CHANGELOG.md
+++ b/packages/popmotion/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Popmotion adheres to [Semantic Versioning](http://semver.org/).
 
+## [8.8.0] 2019-10-01
+
+### Added
+
+- `pause` and `resume` Subscription methods to `chain` and `delay`
+
 ## [8.7.0] 2019-06-25
 
 ### Added

--- a/packages/popmotion/package.json
+++ b/packages/popmotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "popmotion",
-  "version": "8.7.0",
+  "version": "8.8.0",
   "description": "A functional, reactive motion library.",
   "author": "Matt Perry",
   "homepage": "https://popmotion.io",

--- a/packages/popmotion/src/compositors/chain.ts
+++ b/packages/popmotion/src/compositors/chain.ts
@@ -1,25 +1,28 @@
 import action, { Action } from '../action';
 import { ColdSubscription } from '../action/types';
 
-const chain = (...actions: Action[]): Action => action(({ update, complete }) => {
-  let i = 0;
-  let current: ColdSubscription;
+const chain = (...actions: Action[]): Action =>
+  action(({ update, complete }) => {
+    let i = 0;
+    let current: ColdSubscription;
 
-  const playCurrent = () => {
-    current = actions[i].start({
-      complete: () => {
-        i++;
-        (i >= actions.length) ? complete() : playCurrent();
-      },
-      update
-    });
-  };
+    const playCurrent = () => {
+      current = actions[i].start({
+        complete: () => {
+          i++;
+          i >= actions.length ? complete() : playCurrent();
+        },
+        update
+      });
+    };
 
-  playCurrent();
+    playCurrent();
 
-  return {
-    stop: () => current && current.stop()
-  };
-});
+    return {
+      stop: () => current && current.stop(),
+      pause: () => current && current.pause(),
+      resume: () => current && current.resume()
+    };
+  });
 
 export default chain;

--- a/packages/popmotion/src/compositors/delay.ts
+++ b/packages/popmotion/src/compositors/delay.ts
@@ -1,11 +1,27 @@
 import action, { Action } from '../action';
 
-const delay = (timeToDelay: number): Action => action(({ complete }) => {
-  const timeout = setTimeout(complete, timeToDelay);
+const delay = (timeToDelay: number): Action =>
+  action(({ complete }) => {
+    const start = Date.now();
+    let remainingTime = timeToDelay;
+    let timeout = setTimeout(complete, timeToDelay);
 
-  return {
-    stop: () => clearTimeout(timeout)
-  };
-});
+    return {
+      stop() {
+        clearTimeout(timeout);
+        return this;
+      },
+      pause() {
+        clearTimeout(timeout);
+        remainingTime = timeToDelay - (Date.now() - start);
+        return this;
+      },
+      resume() {
+        if (remainingTime < 0) return;
+        timeout = setTimeout(complete, remainingTime);
+        return this;
+      }
+    };
+  });
 
 export default delay;


### PR DESCRIPTION
I ran into the need to be able to pause a `stagger` and it seemed strange that you could in theory pause tweens in a `parallel`, but couldn't pause a `stagger` which uses a `parallel` because it relied upon `chain` & `delay`.

- `chain` passes through `pause` and `resume`, much like  it passes it through for `stop`.
- `delay` will `pause` by `clearTimeout` and taking the remaining time to create a new timeout if there is any, which `resume` will use to create the new remaining time.