### PR TITLE
Fixed TypeScript 3.7 compile with type mergings

### DIFF
--- a/packages/popmotion-pose/src/types.ts
+++ b/packages/popmotion-pose/src/types.ts
@@ -27,10 +27,10 @@ export type Value = {
   type?: ValueType;
 };
 
-export type Pose = Pose<Action, TransitionDefinition>;
-export type PoseMap = PoseMap<Action, TransitionDefinition>;
+export type Pose = PoseCore<Action, TransitionDefinition>;
+export type PoseMap = PoseMapCore<Action, TransitionDefinition>;
 
-export type PoserState = PoserState<
+export type PoserState = PoserStateCore<
   Value,
   Action,
   ColdSubscription,

--- a/packages/popmotion-pose/src/types.ts
+++ b/packages/popmotion-pose/src/types.ts
@@ -11,9 +11,9 @@ import {
 } from 'popmotion';
 import { Poser, PoserConfig } from 'pose-core';
 import {
-  Pose,
-  PoseMap,
-  PoserState,
+  Pose as PoseCore,
+  PoseMap as PoseMapCore,
+  PoserState as PoserStateCore,
   ExtendAPI,
   TransformPose,
   ReadValueFromSource

--- a/packages/stylefire/src/svg/build.ts
+++ b/packages/stylefire/src/svg/build.ts
@@ -1,6 +1,6 @@
 import { camelToDash } from '../styler/utils';
 import { px } from 'style-value-types';
-import { SVGState } from './types';
+import { Dimensions, SVGState } from './types';
 import { camelCaseAttributes } from './attr-formatting';
 import { createStyleBuilder } from '../css/build-styles';
 import { State, ResolvedState } from '../styler/types';

--- a/packages/stylefire/src/svg/build.ts
+++ b/packages/stylefire/src/svg/build.ts
@@ -1,9 +1,11 @@
 import { camelToDash } from '../styler/utils';
 import { px } from 'style-value-types';
-import { Dimensions, SVGState } from './types';
+import { SVGState } from './types';
 import { camelCaseAttributes } from './attr-formatting';
 import { createStyleBuilder } from '../css/build-styles';
 import { State, ResolvedState } from '../styler/types';
+
+
 
 export type SVGAttrs = {
   [key: string]: any;
@@ -21,13 +23,6 @@ const svgAttrsTemplate = (): SVGAttrs => ({
 
 const progressToPixels = (progress: number, length: number) =>
   px.transform(progress * length);
-
-export type Dimensions = {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-};
 
 const unmeasured = { x: 0, y: 0, width: 0, height: 0 };
 

--- a/packages/stylefire/src/svg/build.ts
+++ b/packages/stylefire/src/svg/build.ts
@@ -5,8 +5,6 @@ import { camelCaseAttributes } from './attr-formatting';
 import { createStyleBuilder } from '../css/build-styles';
 import { State, ResolvedState } from '../styler/types';
 
-
-
 export type SVGAttrs = {
   [key: string]: any;
   style?: {


### PR DESCRIPTION
You can no longer override types like this:

```ts
import { MyThing } from 'elsewhere';

export type MyThing = MyThing<boolean>;
```

Fixes #845.