### PR TITLE
fix color test and transform in style-value-types package

### DIFF
--- a/packages/style-value-types/src/_tests/index.test.ts
+++ b/packages/style-value-types/src/_tests/index.test.ts
@@ -127,6 +127,9 @@ describe('rgba()', () => {
   it('should correctly test for colors', () => {
     expect(rgba.test('rgba(255, 0, 0, 0.5)')).toEqual(true);
     expect(rgba.test('rgba(255, 0, 0, 0.5) 0px')).toEqual(false);
+    expect(rgba.test(red)).toEqual(true);
+    expect(rgba.test({ red: '' })).toEqual(false);
+    expect(rgba.test({ red: undefined })).toEqual(false);
   });
 
   it('should split an rgba value into the correct params', () => {
@@ -138,6 +141,9 @@ describe('rgba()', () => {
   it('should correctly combine rgba value', () => {
     expect(rgba.transform(red)).toEqual('rgba(255, 0, 0, 1)');
     expect(rgba.transform(redOutOfRange)).toEqual('rgba(255, 0, 0, 1)');
+    expect(rgba.transform({ green: 0, blue: 0, alpha: 2 })).toEqual(
+      'rgba(0, 0, 0, 1)'
+    );
   });
 });
 
@@ -145,6 +151,9 @@ describe('hsla()', () => {
   it('should correctly test for colors', () => {
     expect(hsla.test('hsla(170, 50%, 45%, 1)')).toEqual(true);
     expect(hsla.test('hsla(170, 50%, 45%, 1) 0px')).toEqual(false);
+    expect(hsla.test(hslaTestColor)).toEqual(true);
+    expect(hsla.test({ hue: '' })).toEqual(false);
+    expect(hsla.test({ hue: undefined })).toEqual(false);
   });
 
   it('should split an hsl value into the correct params', () => {
@@ -156,6 +165,9 @@ describe('hsla()', () => {
   it('should correctly combine hsla value', () => {
     expect(hsla.transform(hslaTestColor)).toEqual('hsla(170, 50%, 45%, 1)');
     expect(hsla.transform(hslaOutOfRange)).toEqual('hsla(170, 50%, 45%, 1)');
+    expect(hsla.transform({ lightness: 45, alpha: 1 })).toEqual(
+      'hsla(0, 0%, 45%, 1)'
+    );
   });
 });
 
@@ -189,6 +201,12 @@ describe('color()', () => {
     expect(color.test('hsla(180, 360%, 360%, 0.5) 0px')).toBe(false);
     expect(color.test('greensock')).toBe(false);
     expect(color.test('filter(190deg)')).toBe(false);
+    expect(color.test(red)).toEqual(true);
+    expect(color.test({ red: '' })).toEqual(false);
+    expect(color.test({ red: undefined })).toEqual(false);
+    expect(color.test(hslaTestColor)).toEqual(true);
+    expect(color.test({ hue: '' })).toEqual(false);
+    expect(color.test({ hue: undefined })).toEqual(false);
   });
 });
 

--- a/packages/style-value-types/src/value-types/color.ts
+++ b/packages/style-value-types/src/value-types/color.ts
@@ -13,8 +13,14 @@ export const getValueFromFunctionString = (value: string) =>
 
 const clampRgbUnit = clamp(0, 255);
 
-const isRgba = (v: Color): v is RGBA => (v as RGBA).red !== undefined;
-const isHsla = (v: Color): v is HSLA => (v as HSLA).hue !== undefined;
+const isColorObj = (keys: string[], obj: any) =>
+  keys.reduce(
+    (acc, key) => acc && obj.hasOwnProperty(key) && obj[key] !== undefined,
+    true
+  );
+const isRgba = (v: Color): v is RGBA => isColorObj(['red', 'green', 'blue'], v);
+const isHsla = (v: Color): v is HSLA =>
+  isColorObj(['hue', 'saturation', 'lightness'], v);
 
 /**
  * Creates a function that will split color
@@ -48,7 +54,7 @@ const hslaTemplate = ({ hue, saturation, lightness, alpha = 1 }: HSLA) =>
 // Value types
 export const rgbUnit: ValueType = {
   ...number,
-  transform: (v: number) => Math.round(clampRgbUnit(v))
+  transform: (v: number) => Math.round(clampRgbUnit(v || 0))
 };
 
 function isColorString(color: string, colorType: '#' | 'hsl' | 'rgb') {
@@ -71,7 +77,7 @@ export const rgba: ValueType = {
 export const hsla: ValueType = {
   test: v => (typeof v === 'string' ? isColorString(v, 'hsl') : isHsla(v)),
   parse: splitColorValues(['hue', 'saturation', 'lightness', 'alpha']),
-  transform: ({ hue, saturation, lightness, alpha = 1 }: HSLA) =>
+  transform: ({ hue = 0, saturation = 0, lightness = 0, alpha = 1 }: HSLA) =>
     hslaTemplate({
       hue: Math.round(hue),
       saturation: percent.transform(sanitize(saturation)),


### PR DESCRIPTION
I'm fixing several color validations for missing cases like `color.test({ red: '' }) === false` or transforms like `hsla.transform({ lightness: 45, alpha: 1 }) === 'hsla(0, 0%, 45%, 1)'`. All cases where data is missing or incorrectly assumed like a valid color input value.
