### PR TITLE
pose-core warn unneed rollup dependency 

### DIFF
--- a/packages/pose-core/package.json
+++ b/packages/pose-core/package.json
@@ -39,7 +39,7 @@
     "prettier": "1.11.1",
     "rollup": "^0.59.1",
     "rollup-plugin-typescript2": "^0.25.2",
-    "typescript": "^2.7.2"
+    "typescript": "^3.7.2"
   },
   "prettier": {
     "parser": "typescript",
@@ -49,8 +49,7 @@
     "@types/invariant": "^2.2.29",
     "@types/node": "^10.0.5",
     "hey-listen": "^1.0.5",
-    "tslib": "^1.10.0",
-    "typescript": "^3.7.2"
+    "tslib": "^1.10.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/packages/pose-core/package.json
+++ b/packages/pose-core/package.json
@@ -38,7 +38,7 @@
     "jest-cli": "^23.1.0",
     "prettier": "1.11.1",
     "rollup": "^0.59.1",
-    "rollup-plugin-typescript2": "^0.14.0",
+    "rollup-plugin-typescript2": "^0.25.2",
     "typescript": "^2.7.2"
   },
   "prettier": {
@@ -49,7 +49,6 @@
     "@types/invariant": "^2.2.29",
     "@types/node": "^10.0.5",
     "hey-listen": "^1.0.5",
-    "rollup-plugin-typescript2": "^0.25.2",
     "tslib": "^1.10.0",
     "typescript": "^3.7.2"
   },


### PR DESCRIPTION
Move `rollup-plugin-typescript2` and `typescript` to devDependency

---

Background: I update popmotion, got those warning

```
warning "react-pose > popmotion-pose > pose-core > rollup-plugin-typescript2@0.25.3" has unmet peer dependency "rollup@>=1.26.3".
```

It's because `rollup-plugin-typescript2` included `dependency` and it's not need on user.