### PR TITLE
Cross-realm safe instanceof checks

### DIFF
--- a/packages/popmotion-pose/src/dom/flip.ts
+++ b/packages/popmotion-pose/src/dom/flip.ts
@@ -27,10 +27,12 @@ const checkPositionalProp = (key: string) => positionalPropsDict.has(key);
 const hasPositionalProps = (pose: Pose) =>
   Object.keys(pose).some(checkPositionalProp);
 
-export const isFlipPose = (flip: boolean, key: string, state: PoserState) =>
-  // acting as cross origin `instanceof HTMLElement`, apparently SVGs have no click method
-  typeof state.props.element.click === 'function' &&
-  (flip === true || key === 'flip');
+export const isFlipPose = (flip: boolean, key: string, state: PoserState) => {
+  return (
+    state.props.element instanceof HTMLElement &&
+    (flip === true || key === 'flip')
+  );
+};
 
 export const setValue = (
   { values, props }: PoserState,
@@ -69,15 +71,12 @@ const explicitlyFlipPose = (state: PoserState, nextPose: Pose) => {
     ...remainingPose
   } = nextPose;
 
-  const propsToSet = positionalProps.concat('position').reduce(
-    (acc, key) => {
-      if (nextPose[key] !== undefined) {
-        acc[key] = resolveProp(nextPose[key], state.props);
-      }
-      return acc;
-    },
-    {} as StyleMap
-  );
+  const propsToSet = positionalProps.concat('position').reduce((acc, key) => {
+    if (nextPose[key] !== undefined) {
+      acc[key] = resolveProp(nextPose[key], state.props);
+    }
+    return acc;
+  }, {} as StyleMap);
 
   elementStyler.set(propsToSet).render();
 

--- a/packages/popmotion-pose/src/dom/flip.ts
+++ b/packages/popmotion-pose/src/dom/flip.ts
@@ -28,7 +28,8 @@ const hasPositionalProps = (pose: Pose) =>
   Object.keys(pose).some(checkPositionalProp);
 
 export const isFlipPose = (flip: boolean, key: string, state: PoserState) =>
-  state.props.element instanceof HTMLElement &&
+  // acting as cross origin `instanceof HTMLElement`, apparently SVGs have no click method
+  typeof state.props.element.click === 'function' &&
   (flip === true || key === 'flip');
 
 export const setValue = (
@@ -94,12 +95,16 @@ const implicitlyFlipPose = (state: PoserState, nextPose: Pose) => {
   const originX =
     prev.left === next.left
       ? ORIGIN_START
-      : prev.right === next.right ? ORIGIN_END : ORIGIN_CENTER;
+      : prev.right === next.right
+      ? ORIGIN_END
+      : ORIGIN_CENTER;
 
   const originY =
     prev.top === next.top
       ? ORIGIN_START
-      : prev.bottom === next.bottom ? ORIGIN_END : ORIGIN_CENTER;
+      : prev.bottom === next.bottom
+      ? ORIGIN_END
+      : ORIGIN_CENTER;
 
   // Set transform origins
   elementStyler.set({ originX, originY });

--- a/packages/react-pose/src/components/PoseElement/index.tsx
+++ b/packages/react-pose/src/components/PoseElement/index.tsx
@@ -147,7 +147,12 @@ class PoseElement extends PureComponent<PoseElementInternalProps> {
     // If we're popping this element out from the DOM flow, build
     // and apply position: absolute styles that visually match the previous
     // location in the DOM
-    if (this.props.popFromFlow && this.ref && this.ref instanceof HTMLElement) {
+    if (
+      this.props.popFromFlow &&
+      this.ref &&
+      // acting as cross origin `instanceof HTMLElement`, apparently SVGs have no click method
+      typeof (this.ref as HTMLElement).click === 'function'
+    ) {
       if (!this.popStyle) {
         props.style = {
           ...props.style,
@@ -166,7 +171,10 @@ class PoseElement extends PureComponent<PoseElementInternalProps> {
 
   setRef = (ref: Element | null) => {
     warning(
-      ref === null || (ref instanceof Element && this.ref === undefined),
+      ref === null ||
+        // acting as cross origin `instanceof Element`
+        (typeof ref.getBoundingClientRect === 'function' &&
+          this.ref === undefined),
       'ref must be provided to the same DOM component for the entire lifecycle of a posed component.'
     );
 

--- a/packages/react-pose/src/components/PoseElement/index.tsx
+++ b/packages/react-pose/src/components/PoseElement/index.tsx
@@ -147,12 +147,7 @@ class PoseElement extends PureComponent<PoseElementInternalProps> {
     // If we're popping this element out from the DOM flow, build
     // and apply position: absolute styles that visually match the previous
     // location in the DOM
-    if (
-      this.props.popFromFlow &&
-      this.ref &&
-      // acting as cross origin `instanceof HTMLElement`, apparently SVGs have no click method
-      typeof (this.ref as HTMLElement).click === 'function'
-    ) {
+    if (this.props.popFromFlow && this.ref && this.ref instanceof HTMLElement) {
       if (!this.popStyle) {
         props.style = {
           ...props.style,
@@ -171,10 +166,7 @@ class PoseElement extends PureComponent<PoseElementInternalProps> {
 
   setRef = (ref: Element | null) => {
     warning(
-      ref === null ||
-        // acting as cross origin `instanceof Element`
-        (typeof ref.getBoundingClientRect === 'function' &&
-          this.ref === undefined),
+      ref === null || (ref instanceof Element && this.ref === undefined),
       'ref must be provided to the same DOM component for the entire lifecycle of a posed component.'
     );
 

--- a/packages/stylefire/src/index.ts
+++ b/packages/stylefire/src/index.ts
@@ -10,15 +10,15 @@ import { Styler, Props } from './styler/types';
 
 const cache = new WeakMap<Element | Window, Styler>();
 
-const isHTMLElement = (element: Element): element is HTMLElement => {
+const isHTMLElement = (node: Element): node is HTMLElement => {
   return (
-    element instanceof HTMLElement ||
+    node instanceof HTMLElement ||
     // Cross-origin safe check
     typeof (node as HTMLElement).click === 'function'
   );
 };
-const isSVGElement = (element: Element): element is SVGElement => {
-  return element instanceof SVGElement || 'ownerSVGElement' in element;
+const isSVGElement = (node: Element): node is SVGElement => {
+  return node instanceof SVGElement || 'ownerSVGElement' in node;
 };
 
 const createDOMStyler = (node: Element | Window, props?: Props) => {

--- a/packages/stylefire/src/index.ts
+++ b/packages/stylefire/src/index.ts
@@ -13,12 +13,14 @@ const cache = new WeakMap<Element | Window, Styler>();
 const createDOMStyler = (node: Element | Window, props?: Props) => {
   let styler: Styler;
 
-  if (node instanceof HTMLElement) {
-    styler = css(node, props);
-  } else if (node instanceof SVGElement) {
-    styler = svg(node);
-  } else if (node === window) {
+  if (node === window) {
     styler = viewport(node);
+  } else if (typeof (node as HTMLElement).click === 'function') {
+    // acting as cross origin `instanceof HTMLElement`, apparently SVGs have no click method
+    styler = css(node as HTMLElement, props);
+  } else if ('ownerSVGElement' in node) {
+    // acting as cross origin `instanceof SVGElement`
+    styler = svg(node);
   }
 
   invariant(

--- a/packages/stylefire/src/index.ts
+++ b/packages/stylefire/src/index.ts
@@ -26,10 +26,10 @@ const createDOMStyler = (node: Element | Window, props?: Props) => {
 
   if (node === window) {
     styler = viewport(node);
-  } else if (isHTMLElement(node)) {
-    styler = css(node, props);
-  } else if (isSVGElement(node)) {
-    styler = svg(node);
+  } else if (isHTMLElement(node as Element)) {
+    styler = css(node as HTMLElement, props);
+  } else if (isSVGElement(node as Element)) {
+    styler = svg(node as SVGElement);
   }
 
   invariant(

--- a/packages/stylefire/src/index.ts
+++ b/packages/stylefire/src/index.ts
@@ -10,16 +10,25 @@ import { Styler, Props } from './styler/types';
 
 const cache = new WeakMap<Element | Window, Styler>();
 
+const isHTMLElement = (element: Element): element is HTMLElement => {
+  return (
+    element instanceof HTMLElement ||
+    // Cross-origin safe check
+    typeof (node as HTMLElement).click === 'function'
+  );
+};
+const isSVGElement = (element: Element): element is SVGElement => {
+  return element instanceof SVGElement || 'ownerSVGElement' in element;
+};
+
 const createDOMStyler = (node: Element | Window, props?: Props) => {
   let styler: Styler;
 
   if (node === window) {
     styler = viewport(node);
-  } else if (typeof (node as HTMLElement).click === 'function') {
-    // acting as cross origin `instanceof HTMLElement`, apparently SVGs have no click method
-    styler = css(node as HTMLElement, props);
-  } else if ('ownerSVGElement' in node) {
-    // acting as cross origin `instanceof SVGElement`
+  } else if (isHTMLElement(node)) {
+    styler = css(node, props);
+  } else if (isSVGElement(node)) {
     styler = svg(node);
   }
 


### PR DESCRIPTION
When accessing elements created within iframes, element's created within a different global scope will not be an instance of HTMLElement etc (HTMLElement actually being window.HTMLElement)

https://codesandbox.io/s/weathered-monad-43fd8