### PR TITLE
Add support for the rrggbbaa hex color notation

### DIFF
--- a/packages/style-value-types/src/_tests/index.test.ts
+++ b/packages/style-value-types/src/_tests/index.test.ts
@@ -20,6 +20,7 @@ const MIXED = '0px 0px 0px rgba(161, 0, 246, 0)';
 
 describe('regex', () => {
   it('should correctly identify values', () => {
+    expect(singleColorRegex.test('#fff00080')).toBe(true);
     expect(singleColorRegex.test('#fff000')).toBe(true);
     expect(singleColorRegex.test('rgba(161, 0, 246, 0)')).toBe(true);
     expect(singleColorRegex.test('#fff000 #fff000')).toBe(false);
@@ -85,6 +86,13 @@ const red = {
   green: 0,
   blue: 0,
   alpha: 1
+};
+
+const transparendRed = {
+  red: 255,
+  green: 0,
+  blue: 0,
+  alpha: 0
 };
 
 const redOutOfRange = {
@@ -168,6 +176,13 @@ describe('color()', () => {
     expect(color.parse(hslaTestColor)).toEqual(hslaTestColor);
   });
 
+  it('should support the alpha channel', () => {
+    expect(color.parse('rgba(255, 0, 0, 0)')).toEqual(transparendRed);
+    expect(color.parse('#ff000000')).toEqual(transparendRed);
+    expect(color.parse('rgba(255, 0, 0, 1)')).toEqual(red);
+    expect(color.parse('#ff0000FF')).toEqual(red);
+  });
+
   it('should correctly combine color value', () => {
     expect(color.transform(red)).toEqual('rgba(255, 0, 0, 1)');
     expect(color.transform(hslaTestColor)).toEqual('hsla(170, 50%, 45%, 1)');
@@ -178,6 +193,7 @@ describe('color()', () => {
     expect(color.test('#fff')).toBe(true);
     expect(color.test('#fff 0px')).toBe(false);
     expect(color.test('#f0f0f0')).toBe(true);
+    expect(color.test('#f0f0f080')).toBe(true);
     expect(color.test('rgb(233, 233, 1)')).toBe(true);
     expect(color.test('rgb(0, 0, 0) 5px 5px 50px 0px')).toBe(false);
     expect(color.test('rgba(255, 255, 0, 1)')).toBe(true);

--- a/packages/style-value-types/src/value-types/color.ts
+++ b/packages/style-value-types/src/value-types/color.ts
@@ -88,12 +88,31 @@ export const hex: ValueType = {
     let r = '';
     let g = '';
     let b = '';
+    let a = 'FF';
 
-    // If we have 6 characters, ie #FF0000
-    if (v.length > 4) {
+    // If we have 8 characters, ie #FF0000FF
+    if (v.length > 8) {
       r = v.substr(1, 2);
       g = v.substr(3, 2);
       b = v.substr(5, 2);
+      a = v.substr(7, 2);
+
+      // Or we have 6 characters, ie #FF0000
+    } else if (v.length > 6) {
+      r = v.substr(1, 2);
+      g = v.substr(3, 2);
+      b = v.substr(5, 2);
+
+      // Or we have 4 characters, ie #F00F
+    } else if (v.length > 4) {
+      r = v.substr(1, 1);
+      g = v.substr(2, 1);
+      b = v.substr(3, 1);
+      a = v.substr(4, 1);
+      r += r;
+      g += g;
+      b += b;
+      a += a;
 
       // Or we have 3 characters, ie #F00
     } else {
@@ -109,7 +128,7 @@ export const hex: ValueType = {
       red: parseInt(r, 16),
       green: parseInt(g, 16),
       blue: parseInt(b, 16),
-      alpha: 1
+      alpha: parseInt(a, 16) / 255
     };
   }
 };


### PR DESCRIPTION
I was animating between some background colours when I noticed - to my horror - that framer-motion was silently dropping the alpha channels from my [hex-RGBA](https://drafts.csswg.org/css-color/#hex-notation) colours.

This adds parsing for `#rrggbbaa` and `#rgba` style colours and tests that the alpha channel is not ignored.