### PR TITLE
have decay resolve amplitude for modified targets

### DIFF
--- a/packages/popmotion/src/animations/decay/index.ts
+++ b/packages/popmotion/src/animations/decay/index.ts
@@ -17,12 +17,13 @@ const decay = (props: DecayProps = {}): Action =>
       modifyTarget
     } = props;
     let elapsed = 0;
-    const amplitude = power * velocity;
+    let amplitude = power * velocity;
     const idealTarget = Math.round(from + amplitude);
     const target =
       typeof modifyTarget === 'undefined'
         ? idealTarget
         : modifyTarget(idealTarget);
+    if (target !== idealTarget) amplitude = target - from;
 
     const process = sync.update(({ delta: frameDelta }) => {
       elapsed += frameDelta;


### PR DESCRIPTION
Anytime I've tried using inertia with `modifyTarget` for snapping behavior it resulted in animations that jerked unexpectedly. After digging in I found it can be fixed quite simply. I've made a [demo](https://codesandbox.io/s/decay-demo-of-issue-and-patch-qr9vi?file=/src/index.js) where the motion of current decay implementation can be compared with a version using this change.