### PR TITLE
Fix decay and inertia

### DIFF
--- a/packages/popmotion/CHANGELOG.md
+++ b/packages/popmotion/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Popmotion adheres to [Semantic Versioning](http://semver.org/).
 
+## [8.7.2] 2020-4-28
+
+### Fixed
+
+- Decay and inertia correctly start motion at from prop when using modifyTarget
+- Decay no longer rounds target calculation
+- Inertia calls modifyTarget even with zero-velocity
+
 ## [8.7.1] 2019-11-14
 
 ### Upgrade

--- a/packages/popmotion/package.json
+++ b/packages/popmotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "popmotion",
-  "version": "8.7.1",
+  "version": "8.7.2",
   "description": "A functional, reactive motion library.",
   "author": "Matt Perry",
   "homepage": "https://popmotion.io",

--- a/packages/popmotion/src/animations/decay/index.ts
+++ b/packages/popmotion/src/animations/decay/index.ts
@@ -17,12 +17,13 @@ const decay = (props: DecayProps = {}): Action =>
       modifyTarget
     } = props;
     let elapsed = 0;
-    const amplitude = power * velocity;
+    let amplitude = power * velocity;
     const idealTarget = Math.round(from + amplitude);
     const target =
       typeof modifyTarget === 'undefined'
         ? idealTarget
         : modifyTarget(idealTarget);
+    if (target !== idealTarget) amplitude = target - from;
 
     const process = sync.update(({ delta: frameDelta }) => {
       elapsed += frameDelta;

--- a/packages/popmotion/src/animations/decay/index.ts
+++ b/packages/popmotion/src/animations/decay/index.ts
@@ -18,7 +18,7 @@ const decay = (props: DecayProps = {}): Action =>
     } = props;
     let elapsed = 0;
     let amplitude = power * velocity;
-    const idealTarget = Math.round(from + amplitude);
+    const idealTarget = from + amplitude;
     const target =
       typeof modifyTarget === 'undefined'
         ? idealTarget

--- a/packages/popmotion/src/animations/inertia/index.ts
+++ b/packages/popmotion/src/animations/inertia/index.ts
@@ -83,7 +83,7 @@ const inertia = ({
       startSpring({ from, velocity });
 
       // Otherwise we want to simulate inertial movement with decay
-    } else if (velocity !== 0) {
+    } else {
       const animation = decay({
         from,
         velocity,
@@ -102,8 +102,6 @@ const inertia = ({
           complete();
         }
       });
-    } else {
-      complete();
     }
 
     return {


### PR DESCRIPTION
When using `modifyTarget` with `decay` or `inertia` the animation can start from an incorrect position (not at `from` prop). This fixes that by having `decay` resolve the amplitude when the target has been modified. I've made a [demo for comparing the motion created by current and patched versions](https://codesandbox.io/s/decay-demo-of-issue-and-patch-qr9vi).

A miniature version of the above problem is the rounding of the target. This only affects animations not using `modifyTarget` and probably isn't visually notable in most cases. This removes that rounding (which is the only instance of any animation rounding anything).

Finally, `inertia` will currently do nothing if `velocity` is zero. Which is unlike `decay` and in multi-axis use, can cause `modifyTarget` to be called only for one axis. So this removes the zero-velocity condition from inertia.