### PR TITLE
Fix decay and inertia, plus refinements

### DIFF
--- a/packages/popmotion/CHANGELOG.md
+++ b/packages/popmotion/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Popmotion adheres to [Semantic Versioning](http://semver.org/).
 
+## [8.7.2] 2020-04-28
+
+### Fixed
+
+- Decay and inertia correctly start motion at from prop when using modifyTarget
+- Decay and inertia no longer round target calculation
+- Inertia calls modifyTarget even with zero-velocity
+
+### Changed
+
+- Inertia implementation refinements
+
 ## [8.7.1] 2019-11-14
 
 ### Upgrade

--- a/packages/popmotion/package.json
+++ b/packages/popmotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "popmotion",
-  "version": "8.7.1",
+  "version": "8.7.2",
   "description": "A functional, reactive motion library.",
   "author": "Matt Perry",
   "homepage": "https://popmotion.io",

--- a/packages/popmotion/src/animations/decay/index.ts
+++ b/packages/popmotion/src/animations/decay/index.ts
@@ -51,3 +51,4 @@ const vectorDecay: ActionFactory = vectorAction(decay, {
 });
 
 export default vectorDecay;
+export { decay as decaySole };

--- a/packages/popmotion/src/animations/decay/index.ts
+++ b/packages/popmotion/src/animations/decay/index.ts
@@ -17,12 +17,13 @@ const decay = (props: DecayProps = {}): Action =>
       modifyTarget
     } = props;
     let elapsed = 0;
-    const amplitude = power * velocity;
+    let amplitude = power * velocity;
     const idealTarget = Math.round(from + amplitude);
     const target =
       typeof modifyTarget === 'undefined'
         ? idealTarget
         : modifyTarget(idealTarget);
+    if (target !== idealTarget) amplitude = target - from;
 
     const process = sync.update(({ delta: frameDelta }) => {
       elapsed += frameDelta;

--- a/packages/popmotion/src/animations/decay/index.ts
+++ b/packages/popmotion/src/animations/decay/index.ts
@@ -18,7 +18,7 @@ const decay = (props: DecayProps = {}): Action =>
     } = props;
     let elapsed = 0;
     let amplitude = power * velocity;
-    const idealTarget = Math.round(from + amplitude);
+    const idealTarget = from + amplitude;
     const target =
       typeof modifyTarget === 'undefined'
         ? idealTarget

--- a/packages/popmotion/src/animations/inertia/index.ts
+++ b/packages/popmotion/src/animations/inertia/index.ts
@@ -65,7 +65,7 @@ const inertia = ({
       // Otherwise simulate inertial movement with decay. If target is beyond
       // bounds switch from decay to spring upon boundary encounter
     } else {
-      let to = Math.round(power * velocity + from);
+      let to = power * velocity + from;
       if (typeof modifyTarget !== 'undefined') {
         // get the modified target, prevent decay doing so a second time and
         // resolve velocity so decay will produce the modified target

--- a/packages/popmotion/src/animations/inertia/index.ts
+++ b/packages/popmotion/src/animations/inertia/index.ts
@@ -83,7 +83,7 @@ const inertia = ({
       startSpring({ from, velocity });
 
       // Otherwise we want to simulate inertial movement with decay
-    } else if (velocity !== 0) {
+    } else {
       const animation = decay({
         from,
         velocity,
@@ -102,8 +102,6 @@ const inertia = ({
           complete();
         }
       });
-    } else {
-      complete();
     }
 
     return {

--- a/packages/popmotion/src/animations/inertia/index.ts
+++ b/packages/popmotion/src/animations/inertia/index.ts
@@ -2,8 +2,8 @@ import { number } from 'style-value-types';
 import action, { Action } from '../../action';
 import vectorAction, { ActionFactory } from '../../action/vector';
 import value from '../../reactions/value';
-import spring from '../spring';
-import decay from '../decay';
+import { springSole } from '../spring';
+import { decaySole } from '../decay';
 import { ColdSubscription } from '../../action/types';
 import { Props, SpringProps } from './types';
 
@@ -52,7 +52,7 @@ const inertia = ({
     const startSpring = (props: SpringProps) => {
       isSpring = true;
       startAnimation(
-        spring({
+        springSole({
           ...props,
           to: isLessThanMin(props.from) ? min : max,
           stiffness: bounceStiffness,
@@ -84,7 +84,7 @@ const inertia = ({
 
       // Otherwise we want to simulate inertial movement with decay
     } else {
-      const animation = decay({
+      const animation = decaySole({
         from,
         velocity,
         timeConstant,

--- a/packages/popmotion/src/animations/inertia/types.ts
+++ b/packages/popmotion/src/animations/inertia/types.ts
@@ -12,6 +12,7 @@ export type Props = {
 };
 
 export type SpringProps = {
+  to: number;
   from: number;
   velocity: number;
 };

--- a/packages/popmotion/src/animations/spring/index.ts
+++ b/packages/popmotion/src/animations/spring/index.ts
@@ -88,3 +88,4 @@ const vectorSpring: ActionFactory = vectorAction(spring, {
 });
 
 export default vectorSpring;
+export { spring as springSole };


### PR DESCRIPTION
This PR includes the fixes from #873 plus some changes that lighten and tighten inertia's implementation a bit.

[4c9f561 streamline subordinate action creation in inertia](https://github.com/Popmotion/popmotion/commit/4c9f561d672caf9855f816f39f8645423a7c1547)
`inertia` exports a `VectorActionFactory` and imports `decay` and `spring` as such. Thus when inertia creates the decay or spring animations redundant logic for vector actions is ran. By importing and using the single versions of decay and spring that is avoided. 

[eb254d4 tighten logic for switching animations in inertia](https://github.com/Popmotion/popmotion/commit/eb254d4ddb7bc0c2f76f1ede054396b9838b0082)
I couldn't help but wonder why inertia didn't use a while predicate on decay for the logic of checking boundaries and switching to spring. So it tried it out and found a few other small ways to refine the implementation.

[b07fdef remove value reaction from inertia](https://github.com/Popmotion/popmotion/commit/b07fdef021540cd1e103e2d34fe8273672c3958c)
It seemed like manually tracking velocity to drop reliance on value reaction was worthwhile for slightly less overhead. Also in the odd case that someone just wants inertia and not reactions they can be treeshakened.