### PR TITLE
mend rollup config generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://popmotion.io",
   "scripts": {
     "bootstrap": "lerna bootstrap",
-    "build": "cd packages/easing && yarn build && cd ../style-value-types && yarn build && cd ../framesync && yarn build && cd ../popcorn && yarn build && cd ../stylefire && yarn build && cd ../popmotion && yarn build && cd ../pose-core && yarn build && cd ../animated-pose && yarn build && cd ../react-pose-core && yarn build && cd ../react-native-pose && yarn build && cd ../popmotion-pose && yarn build && cd ../react-pose && yarn build && yarn build && cd ../react-pose-text && yarn build",
+    "build": "cd packages/easing && yarn build && cd ../style-value-types && yarn build && cd ../framesync && yarn build && cd ../popcorn && yarn build && cd ../stylefire && yarn build && cd ../popmotion && yarn build && cd ../pose-core && yarn build && cd ../animated-pose && yarn build && cd ../react-pose-core && yarn build && cd ../react-native-pose && yarn build && cd ../popmotion-pose && yarn build && cd ../react-pose && yarn build && cd ../react-pose-text && yarn build",
     "playground": "start-storybook -p 6006",
     "build-playground": "build-storybook",
     "clean": "lerna clean --yes && rm -rf node_modules",

--- a/rollup-generate-config.js
+++ b/rollup-generate-config.js
@@ -1,8 +1,13 @@
 import typescript from 'rollup-plugin-typescript2';
+import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import { uglify } from 'rollup-plugin-uglify';
 
 const typescriptConfig = { cacheRoot: 'tmp/.rpt2_cache' };
+const noDeclarationConfig = {
+  ...typescriptConfig,
+  tsconfigOverride: { compilerOptions: { declaration: false } }
+};
 
 const makeExternalPredicate = externalArr => {
   if (externalArr.length === 0) {
@@ -40,8 +45,10 @@ export default function(pkg, name = pkg.name) {
         '@popmotion/popcorn': 'popcorn'
       }
     },
+    external: makeExternalPredicate(peerDeps),
     plugins: [
-      typescript(typescriptConfig),
+      resolve(),
+      typescript(noDeclarationConfig),
       replace({
         'process.env.NODE_ENV': JSON.stringify('development')
       })
@@ -49,13 +56,14 @@ export default function(pkg, name = pkg.name) {
   };
 
   const umdProd = {
-    ...config,
+    ...umd,
     output: {
       ...umd.output,
-      file: `dist/${name}.min.js`
+      file: pkg.unpkg || `dist/${name}.min.js`
     },
     plugins: [
-      typescript(typescriptConfig),
+      resolve(),
+      typescript(noDeclarationConfig),
       replace({
         'process.env.NODE_ENV': JSON.stringify('production')
       }),
@@ -70,7 +78,7 @@ export default function(pkg, name = pkg.name) {
       file: pkg.module,
       format: 'es'
     },
-    plugins: [typescript(typescriptConfig)]
+    plugins: [typescript(noDeclarationConfig)]
   };
 
   const cjs = {


### PR DESCRIPTION
getting back details lost when switching to generator
- import and use resolve plugin for umd/umdProd
- use no declaration typescript config for all but cjs
- use unpkg field when available for file in umdProd
- remove doubled up yarn build in root scripts build

fixes #875

I've not tested every package but seems to work well for pure, stylefire, framesync and popcorn. 