### PR TITLE
Indicate that package has no sideEffects

### DIFF
--- a/packages/popmotion/package.json
+++ b/packages/popmotion/package.json
@@ -8,6 +8,7 @@
   "types": "./lib/index.d.ts",
   "module": "dist/popmotion.es.js",
   "jsnext:main": "dist/popmotion.es.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/Popmotion/popmotion/tree/master/packages/popmotion"


### PR DESCRIPTION
To help tree shaking in Webpack as Webpack for compatibility reasons otherwise will assume that we package will have sideEffects.

See: https://github.com/stereobooster/package.json#sideeffects
And: https://webpack.js.org/guides/tree-shaking/
