### PR TITLE
fix declaration of ValueReaction

### DIFF
--- a/packages/popmotion/CHANGELOG.md
+++ b/packages/popmotion/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Popmotion adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Revised ValueReaction so its declaration is static [#580](https://github.com/framer/motion/issues/580)
+
+## [8.7.3] 2020-05-08
+
+### Fixed
+
+- Cleaned release [#878](https://github.com/Popmotion/popmotion/issues/878)
+
 ## [8.7.2] 2020-04-28
 
 ### Fixed
@@ -30,7 +42,7 @@ Popmotion adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fixing undefined action creator. (https://github.com/Popmotion/popmotion/issues/794)[#794]
+- Fixing undefined action creator. [#794](https://github.com/Popmotion/popmotion/issues/794)
 
 ## [8.6.9] 2019-05-01
 
@@ -48,7 +60,7 @@ Popmotion adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Making `inertia.complete` call conditional on there not being a subsequent animation. (https://github.com/Popmotion/popmotion/pull/763)[#763]
+- Making `inertia.complete` call conditional on there not being a subsequent animation. [#763](https://github.com/Popmotion/popmotion/pull/763)
 
 ## [8.6.6] 2019-04-01
 

--- a/packages/popmotion/package.json
+++ b/packages/popmotion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "popmotion",
-  "version": "8.7.3",
+  "version": "8.7.4",
   "description": "A functional, reactive motion library.",
   "author": "Matt Perry",
   "homepage": "https://popmotion.io",

--- a/packages/popmotion/src/reactions/value.ts
+++ b/packages/popmotion/src/reactions/value.ts
@@ -79,7 +79,9 @@ export class ValueReaction extends BaseMulticast<ValueReaction> {
     sync.postRender(this.scheduleVelocityCheck);
   }
 
-  scheduleVelocityCheck = () => sync.postRender(this.velocityCheck);
+  scheduleVelocityCheck = () => {
+    sync.postRender(this.velocityCheck);
+  };
 
   velocityCheck = ({ timestamp }: FrameData) => {
     if (timestamp !== this.lastUpdated) {


### PR DESCRIPTION
[EDIT] Reverted a hasty extra change, so now besides a few extra format fixes in the changelog this PR just:
Rids the `ValueReaction` declaration of a dynamic import by putting the body of `scheduleVelocityCheck` inside `{}` to avoid the implicit return.

prepares fix for framer/motion#580

I updated the version and changelog but additions aren't yet under a version/date header. If you'd prefer I'll put them under one. 