### PR TITLE
Fix stylefire docs

### DIFF
--- a/packages/site/pages/stylefire/api/html.js
+++ b/packages/site/pages/stylefire/api/html.js
@@ -107,8 +107,8 @@ htmlRenderer.set('--bg-color', '#000');
 
 **All CSS properties are supported**, in addition to these scroll properties:
 
-* \`scrollX\`
-* \`scrollY\`
+* \`scrollLeft\`
+* \`scrollTop\`
 
 If \`window\` is passed to styler, these are the **only** two supported props.
 


### PR DESCRIPTION
Looks like these props are now 'scrollTop' and 'scrollLeft'. 

--- 

A slightly related question: 

Since stylefire is no longer exported from the popmotion package, is there some other way you are expected to actually execute an animation with v9?

Or are you still supposed to create/user a styler like before, but are now expected to `import styler from 'stylefire'`?

Thanks