### PR TITLE
Update `export` maps for TypeScript 4.7+

### DIFF
--- a/packages/framesync/package.json
+++ b/packages/framesync/package.json
@@ -12,6 +12,7 @@
     "unpkg": "./dist/framesync.min.js",
     "exports": {
         ".": {
+            "types": "./lib/index.d.ts",
             "import": "./dist/es/index.mjs",
             "require": "./dist/framesync.cjs.js",
             "default": "./dist/framesync.cjs.js"

--- a/packages/popmotion/package.json
+++ b/packages/popmotion/package.json
@@ -11,6 +11,7 @@
     "unpkg": "./dist/popmotion.min.js",
     "exports": {
         ".": {
+            "types": "./lib/index.d.ts",
             "import": "./dist/es/index.mjs",
             "require": "./dist/popmotion.cjs.js",
             "default": "./dist/popmotion.cjs.js"

--- a/packages/projection/package.json
+++ b/packages/projection/package.json
@@ -11,6 +11,7 @@
     "unpkg": "./dist/projection.min.js",
     "exports": {
         ".": {
+            "types": "./lib/index.d.ts",
             "import": "./dist/es/index.mjs",
             "require": "./dist/projection.cjs.js",
             "default": "./dist/projection.cjs.js"

--- a/packages/style-value-types/package.json
+++ b/packages/style-value-types/package.json
@@ -8,6 +8,7 @@
   "jsnext:main": "dist/es/index.mjs",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./dist/es/index.mjs",
       "require": "./dist/valueTypes.cjs.js",
       "default": "./dist/valueTypes.cjs.js"


### PR DESCRIPTION
TypeScript 4.7 (soon to be released) now has support for `exports` maps in `package.json` and ES module output. In packages that already provide an `exports` field, this can end up hiding the `types` field, causing builds to break.

These changes should resolve that by specifying `types` in the `exports` map itself.