### PR TITLE
Updated the footer link text

### DIFF
--- a/packages/site/components/template.js
+++ b/packages/site/components/template.js
@@ -126,7 +126,7 @@ export default function ({ children, tableOfContents }) {
                 <a href="/pose">Pose</a>
               </li>
               <li>
-                <a href="/pure">Popmotion 8</a>
+                <a href="/pure">Popmotion Pure</a>
               </li>
             </ul>
             <div>


### PR DESCRIPTION
 #956
it previously showing popmotion 8 in footer and after clicking to it the link takes you to the popmotion pure site  so it'll be more benificial for the users to keep it simple like as popmotion pure.